### PR TITLE
Set nearest filtering in GL CopyImage tests.

### DIFF
--- a/external/openglcts/modules/gl/gl4cCopyImageTests.cpp
+++ b/external/openglcts/modules/gl/gl4cCopyImageTests.cpp
@@ -1371,6 +1371,27 @@ void Utils::makeTextureComplete(deqp::Context& context, GLenum target, GLuint id
 
 		gl.texParameteri(target, GL_TEXTURE_MAX_LEVEL, max_level);
 		GLU_EXPECT_NO_ERROR(gl.getError(), "TexParameteri");
+
+		/* Integer textures won't be complete with the default min filter
+		 * of GL_NEAREST_MIPMAP_LINEAR (or GL_LINEAR for rectangle textures)
+		 * and default mag filter of GL_LINEAR, so switch to nearest.
+		 */
+		if (GL_TEXTURE_2D_MULTISAMPLE != target &&
+			GL_TEXTURE_2D_MULTISAMPLE_ARRAY != target)
+		{
+			gl.texParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			if (GL_TEXTURE_RECTANGLE != target)
+			{
+				gl.texParameteri(target, GL_TEXTURE_MIN_FILTER,
+								 GL_NEAREST_MIPMAP_NEAREST);
+				GLU_EXPECT_NO_ERROR(gl.getError(), "TexParameteri");
+			}
+			else
+			{
+				gl.texParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+				GLU_EXPECT_NO_ERROR(gl.getError(), "TexParameteri");
+			}
+		}
 	}
 
 	/* Clean binding point */


### PR DESCRIPTION
glCopyImageSubData requires textures to be mipmap complete.  These
tests create integer textures, but left the default min filter of
GL_NEAREST_MIPMAP_LINEAR or GL_LINEAR (for rectangle textures) in
place.  The completeness rules say that integer textures cannot be
mipmap complete with linear filtering.

Affects:
- GL45-CTS.copy_image.smoke_test
- GL45-CTS.copy_image.incompatible_formats
- GL45-CTS.copy_image.incompatible_formats_compression

Components: OpenGL
Khronos bugzilla: 16224