### PR TITLE
try to run deqp::ShaderIntegerMixTests in OpenGL 4.5 context

### DIFF
--- a/external/openglcts/modules/gl/gl3cTestPackages.cpp
+++ b/external/openglcts/modules/gl/gl3cTestPackages.cpp
@@ -239,7 +239,7 @@ public:
 		addChild(new deqp::ShaderStructTests(m_context, glu::GLSL_VERSION_330));
 		addChild(new deqp::ShaderSwitchTests(m_context, glu::GLSL_VERSION_330));
 		addChild(new deqp::UniformBlockTests(m_context, glu::GLSL_VERSION_330));
-		addChild(new deqp::ShaderIntegerMixTests(m_context, glu::GLSL_VERSION_330));
+		addChild(new deqp::ShaderIntegerMixTests(m_context, glu::GLSL_VERSION_450));
 		addChild(new deqp::ShaderNegativeTests(m_context, glu::GLSL_VERSION_330));
 	}
 };


### PR DESCRIPTION
Without the patch a Core Context with OpenGL 3.3 is requested and the check against shader_integer_mix fails leading to the test being marked as "Not supported" due to this line of Code:
https://github.com/KhronosGroup/VK-GL-CTS/blob/dfcb8e870438f6f2bfe71d4bb63d43120debb3a3/external/openglcts/modules/common/glcShaderIntegerMixTests.cpp#L224

I am not quite sure if this tests breaks driver exporting that extension not advertising GLSL 450

Affects 'KHR-GL45.shaders.shader_integer_mix.prototypes'