### PR TITLE
GLXY-CTS should be changed to KHR-GLXY

### DIFF
--- a/external/openglcts/README.md
+++ b/external/openglcts/README.md
@@ -517,7 +517,7 @@ Note that the GL context version is determined by the case name. `KHR-GLES3` in
 the example above selects OpenGL ES 3.0. The command to run the same test
 against OpenGL version 4.1 is:
 
-	Debug/glcts.exe --deqp-case=GL41-CTS.shaders.loops.* --deqp-gl-config-id=3
+	Debug/glcts.exe --deqp-case=KHR-GL45.shaders.loops.* --deqp-gl-config-id=3
 
 To list available test cases (writes out `*-cases.txt` files per module), run:
 


### PR DESCRIPTION
It appears that the old test naming of GLXY-CTS, where X is GL major version and Y is minor version no longer works. Instead users should use KHR-GLXY. This change appears to have already been made for GL-ES a few lines up, but not for GL.