### PR TITLE
Generating caselist uses generic surface type

### DIFF
--- a/framework/platform/win32/tcuWGLContextFactory.cpp
+++ b/framework/platform/win32/tcuWGLContextFactory.cpp
@@ -98,7 +98,8 @@ WGLContext::WGLContext (HINSTANCE instance, const wgl::Core& wglCore, const glu:
 	, m_context		(DE_NULL)
 {
 	if (config.surfaceType != glu::RenderConfig::SURFACETYPE_WINDOW &&
-		config.surfaceType != glu::RenderConfig::SURFACETYPE_DONT_CARE)
+		config.surfaceType != glu::RenderConfig::SURFACETYPE_DONT_CARE &&
+		config.surfaceType != glu::RenderConfig::SURFACETYPE_OFFSCREEN_GENERIC)
 		throw NotSupportedError("Unsupported surface type");
 
 	HDC		deviceCtx	= m_window.getDeviceContext();


### PR DESCRIPTION
When running this command:
Debug\glcts.exe --deqp-case=KHR-GL45.* --deqp-runmode=txt-caselist

The application reports an unsupported surface type. Adding SURFACETYPE_OFFSCREEN_GENERIC to the supported surface types for generating text caselist.