### PR TITLE
Fix build when .git is a gitlink file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # dEQP cmake file
 
-cmake_minimum_required(VERSION 2.8)
+# Module FindGit requires cmake >= 2.8.2
+cmake_minimum_required(VERSION 2.8.2)
+
+find_package(Git)
 
 # dEQP Target.
 set(DEQP_TARGET "default" CACHE STRING "dEQP Target (default, android...)")

--- a/framework/qphelper/CMakeLists.txt
+++ b/framework/qphelper/CMakeLists.txt
@@ -43,15 +43,19 @@ set(USE_RELEASE_INFO_FILE OFF)
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/qpReleaseInfo.inl")
 	set(USE_RELEASE_INFO_FILE ON)
 
-elseif (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+elseif (EXISTS "${CMAKE_SOURCE_DIR}/.git" AND Git_FOUND)
 	find_package(PythonInterp 2.7)
 
 	if (PYTHON_EXECUTABLE)
 		message(STATUS "Using git revision as release identifier")
 
+		execute_process(COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_SOURCE_DIR}/.git rev-parse --git-dir
+						OUTPUT_VARIABLE DE_GIT_DIR
+						OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 		add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/qpReleaseInfo.inl
-						   COMMAND ${PYTHON_EXECUTABLE} -B ${CMAKE_CURRENT_SOURCE_DIR}/gen_release_info.py --git --out=${CMAKE_CURRENT_BINARY_DIR}/qpReleaseInfo.inl
-						   DEPENDS gen_release_info.py ${CMAKE_SOURCE_DIR}/.git/HEAD ${CMAKE_SOURCE_DIR}/.git/index) # \note HEAD updated only when changing branches
+						   COMMAND ${PYTHON_EXECUTABLE} -B ${CMAKE_CURRENT_SOURCE_DIR}/gen_release_info.py --git --git-dir=${DE_GIT_DIR} --out=${CMAKE_CURRENT_BINARY_DIR}/qpReleaseInfo.inl
+						   DEPENDS gen_release_info.py ${DE_GIT_DIR}/HEAD ${DE_GIT_DIR}/index) # \note HEAD updated only when changing branches
 		add_custom_target(git-rel-info DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/qpReleaseInfo.inl)
 		add_dependencies(qphelper git-rel-info)
 		include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/framework/qphelper/gen_release_info.py
+++ b/framework/qphelper/gen_release_info.py
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------
 
 import os
-import re
+import subprocess
 import sys
 import argparse
 
@@ -36,28 +36,10 @@ def writeFile (filename, data):
 	f.write(data)
 	f.close()
 
-COMMIT	= 0
-REF		= 1
-
-def getCommitOrRef (filename):
-	src = readFile(filename)
-	m = re.search(r'^[a-zA-Z0-9]{40}', src)
-	if m:
-		return (COMMIT, m.group(0))
-	m = re.search(r'^ref:\s+([^\s]+)', src)
-	if m:
-		return (REF, m.group(1))
-	raise Exception("Coulnd't parse %s" % filename)
-
 def getHead (gitDir):
-	curFile = os.path.join(gitDir, "HEAD")
-	while True:
-		type, ptr = getCommitOrRef(curFile)
-		if type == COMMIT:
-			return ptr
-		else:
-			assert type == REF
-			curFile = os.path.join(gitDir, ptr)
+	commit = subprocess.check_output(["git", "--git-dir", gitDir,
+									  "rev-parse", "HEAD"])
+	return commit.decode().strip()
 
 def makeReleaseInfo (name, id):
 	return """


### PR DESCRIPTION
If ${CMAKE_SOURCE_DIR}/.git exists, then
framework/qphelper/CMakeLists.txt uses the git revision as the dEQP
revision. The CMake rules update the revision when the files
${CMAKE_SOURCE_DIR}/.git/HEAD and ${CMAKE_SOURCE_DIR}/.git/index
change.

However, Git does not require that .git be a directory. If
git-submodules or git-worktrees are used, then .git may be a gitlink
file instead and the real git directory is elsewhere.

Fix the build by using `git rev-parse --git-dir` to find the real git dir
and `git rev-parse HEAD` to query the commit sha1.

This bumps the CMake requirement from 2.8 to 2.8.2. But that should be
safe since 2.8.2 was released in 2010.

Change-Id: I811630e5afada8e6aed611b0ef6c51e39be2200b