### PR TITLE
Accept EGL_BAD_PARAMETER for eglCreatePixmapSurface negative test

### DIFF
--- a/modules/egl/teglNegativeApiTests.cpp
+++ b/modules/egl/teglNegativeApiTests.cpp
@@ -661,10 +661,10 @@ void NegativeApiTests::init (void)
 
 			log << TestLog::EndSection;
 
-			log << TestLog::Section("Test2", "EGL_BAD_CONFIG is generated if config is not an EGL frame buffer configuration");
+			log << TestLog::Section("Test2", "EGL_BAD_CONFIG or EGL_BAD_PARAMETER is generated if config is not an EGL frame buffer configuration or if the PixmapSurface call is not supported");
 
 			expectNoSurface(eglCreatePixmapSurface(display, (EGLConfig)-1, DE_NULL, s_emptyAttribList));
-			expectError(EGL_BAD_CONFIG);
+			expectEitherError(EGL_BAD_CONFIG, EGL_BAD_PARAMETER);
 
 			log << TestLog::EndSection;
 		});


### PR DESCRIPTION
Running CTS conformance test on wayland results in test failure for
dEQP-EGL.functional.negative_api.create_pixmap_surface, since the test
expects EGL_BAD_CONFIG, but actual returned error is EGL_BAD_PARAMETER.

According to EGL_EXT_platform_wayland spec,
(https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_wayland.txt)
any call to eglCreatePlatformPixmapSurfaceEXT() on wayland will return
EGL_BAD_PARAMETER.

Ideally, both eglCreatePixmapSurface() and
eglCreatePlatformPixmapSurfaceEXT() should be considered the same, since
internally both calls do the same thing.

This is one of those situations where multiple errors could be reported
given that multiple invalid parameters are provided (invalid platform +
invalid config).

This change accepts both error values EGL_BAD_CONFIG and
EGL_BAD_PARAMETER for eglCreatePixmapSurface negative test.

VK-GL-CTS issue: 68

Affects: dEQP-EGL.functional.negative_api.create_pixmap_surface
Test: Run the test on wayland platforms