### PR TITLE
WIP: Port surfaceless platform

### DIFF
--- a/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
+++ b/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
@@ -32,6 +32,7 @@
 #include "deSTLUtil.hpp"
 #include "egluUtil.hpp"
 #include "egluGLUtil.hpp"
+#include "egluPlatform.hpp"
 #include "eglwEnums.hpp"
 #include "eglwLibrary.hpp"
 #include "gluPlatform.hpp"
@@ -179,11 +180,12 @@ private:
 	de::DynamicLibrary*		m_library;
 };
 
-class Platform : public tcu::Platform, public glu::Platform
+class Platform : public tcu::Platform, public glu::Platform, public eglu::Platform
 {
 public:
 					Platform	(void);
 	const glu::Platform&		getGLPlatform	(void) const { return *this; }
+	const eglu::Platform&		getEGLPlatform	(void) const { return *this; }
 	const vk::Platform&			getVulkanPlatform	(void) const { return m_vkPlatform; }
 
 private:

--- a/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
+++ b/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
@@ -45,8 +45,6 @@
 #include "tcuRenderTarget.hpp"
 #include "vkPlatform.hpp"
 
-#include <EGL/egl.h>
-
 using std::string;
 using std::vector;
 
@@ -329,10 +327,10 @@ EglRenderContext::EglRenderContext(const glu::RenderConfig& config, const tcu::C
 
 	frame_buffer_attribs.push_back(EGL_NONE);
 
-	if (!eglChooseConfig(m_eglDisplay, &frame_buffer_attribs[0], NULL, 0, &num_configs))
+	if (!m_egl.chooseConfig(m_eglDisplay, &frame_buffer_attribs[0], NULL, 0, &num_configs))
 		throw tcu::ResourceError("surfaceless couldn't find any config");
 
-	if (!eglChooseConfig(m_eglDisplay, &frame_buffer_attribs[0], &egl_config, 1, &num_configs))
+	if (!m_egl.chooseConfig(m_eglDisplay, &frame_buffer_attribs[0], &egl_config, 1, &num_configs))
 		throw tcu::ResourceError("surfaceless couldn't find any config");
 
 	switch (config.surfaceType)
@@ -341,7 +339,7 @@ EglRenderContext::EglRenderContext(const glu::RenderConfig& config, const tcu::C
 			egl_surface = EGL_NO_SURFACE;
 			break;
 		case glu::RenderConfig::SURFACETYPE_OFFSCREEN_GENERIC:
-			egl_surface = eglCreatePbufferSurface(m_eglDisplay, egl_config, &surface_attribs[0]);
+			egl_surface = m_egl.createPbufferSurface(m_eglDisplay, egl_config, &surface_attribs[0]);
 			break;
 	}
 

--- a/targets/surfaceless/surfaceless.cmake
+++ b/targets/surfaceless/surfaceless.cmake
@@ -35,13 +35,12 @@ pkg_check_modules(EGL REQUIRED egl)
 set(DEQP_EGL_LIBRARIES ${EGL_LIBRARIES})
 
 pkg_check_modules(GBM REQUIRED gbm)
-pkg_check_modules(KMS REQUIRED libkms)
 pkg_check_modules(DRM REQUIRED libdrm)
 
 include_directories(${GLES2_INCLUDE_PATH} ${GLES3_INCLUDE_PATH}
                     ${EGL_INCLUDE_DIRS} ${GBM_INCLUDE_DIRS}
-                    ${KMS_INCLUDE_DIRS} ${DRM_INCLUDE_DIRS})
+                    ${DRM_INCLUDE_DIRS})
 
 set(DEQP_PLATFORM_LIBRARIES ${DEQP_GLES2_LIBRARIES} ${DEQP_GLES3_LIBRARIES}
                             ${DEQP_EGL_LIBRARIES} ${GBM_LIBRARIES}
-                            ${KMS_LIBRARIES} ${DRM_LIBRARIES})
+                            ${DRM_LIBRARIES})


### PR DESCRIPTION
The surfaceless platform looks like it got merged from android's DEQP, but hasn't been ported over for changes in the tcu interfaces.  This is my attempt at doing so, currently failing at:

```
/home/anholt/src/rpi2/khronos-conformance/external/openglcts/modules/glcts 
Writing test log into TestResults.qpa
dEQP Core git-5efed21924a40284dd6a135b6778f1402e104810 (0x5efed219) starting..
  target implementation = 'Surfaceless'

Test case 'CTS-Configs.es2'..
glcts: framework/common/tcuFactoryRegistry.cpp:59: Unknown function: Assertion `index < m_factories.size()' failed.
```

@chadversary any interest on your part?