### PR TITLE
glx: add getProcAddress override

### DIFF
--- a/framework/platform/lnx/X11/tcuLnxX11GlxPlatform.cpp
+++ b/framework/platform/lnx/X11/tcuLnxX11GlxPlatform.cpp
@@ -183,6 +183,7 @@ public:
 	void								clearCurrent		(void);
 	virtual const glw::Functions&		getFunctions		(void) const;
 	virtual const tcu::RenderTarget&	getRenderTarget		(void) const;
+	virtual glw::GenericFuncType		getProcAddress		(const char* name) const;
 	const GLXContext&					getGLXContext		(void) const;
 
 private:
@@ -732,6 +733,11 @@ void GlxRenderContext::clearCurrent (void)
 {
 	TCU_CHECK_GLX(glXMakeContextCurrent(m_glxDisplay.getXDisplay(),
 										None, None, DE_NULL));
+}
+
+glw::GenericFuncType GlxRenderContext::getProcAddress(const char *name) const
+{
+	return glXGetProcAddress(reinterpret_cast<const GLubyte*>(name));
 }
 
 ContextType GlxRenderContext::getType (void) const


### PR DESCRIPTION
The regular function pointers are filled in on load, but any additional
pointers, potentially from extensions, requested by tests would end up
with NULLs, triggering failures.

Affects:
KHR-GL45.transform_feedback.draw_xfb_instanced_test
KHR-GL45.transform_feedback.draw_xfb_stream_instanced_test