### PR TITLE
Fix: add missing templeate to fix build issue for es-3.2.2 branch

### DIFF
--- a/external/openglcts/modules/gles31/es31cDrawIndirectTests.cpp
+++ b/external/openglcts/modules/gles31/es31cDrawIndirectTests.cpp
@@ -1739,7 +1739,7 @@ struct CBufferBindRange : public DrawIndirectBase
 		result.sub_result(DataCompare(dataRef, dataWidth, dataHeight, dataTest, dataWidth, dataHeight));
 
 		glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
-		result.sub_result(BindingPointCheck(0));
+		result.sub_result(BindingPointCheck<api>(0));
 
 		glBindBufferRange(GL_DRAW_INDIRECT_BUFFER, 0, _buffer, 0, dataTest.size() * sizeof(unsigned int) / 4);
 		result.sub_result(BindingPointCheck<api>(_buffer));
@@ -1824,7 +1824,7 @@ struct CBufferBindBase : public DrawIndirectBase
 
 		GetBufferSubData<api>(GL_DRAW_INDIRECT_BUFFER, 0, dataTest.size() * sizeof(unsigned int), &dataTest[0]);
 		result.sub_result(DataCompare(dataRef1, dataWidth, dataHeight, dataTest, dataWidth, dataHeight));
-		result.sub_result(BindingPointCheck(_buffers[0]));
+		result.sub_result(BindingPointCheck<api>(_buffers[0]));
 
 		glBindBufferBase(GL_DRAW_INDIRECT_BUFFER, 0, _buffers[1]);
 		result.sub_result(BindingPointCheck<api>(_buffers[1]));


### PR DESCRIPTION
I am not sure whether opengl-es-cts-3.2.2 is still alive to accept changes. 

I have some patches to fix bugs in gles 3.1 cts in dEQP project, see the original patches at https://android-review.googlesource.com/c/platform/external/deqp/+/631598 and https://android-review.googlesource.com/c/platform/external/deqp/+/630411. And some others are at my local machine. @chrisforbes and @alegal-arm suggested me to submit dEQP patches to VK-GL-CTS. 

According to the suggestion at https://github.com/KhronosGroup/VK-GL-CTS/wiki/Contributing, bug fixes should go to the branch that the bug was first introduced. GLES 3.1 cts bug should be first introduced at branch like opengl-es-cts-3.1.*, but there is no such branch. Currently the oldest branch is opengl-es-cts-3.2.2, so I suppose I should submit to that branch. However, the code from opengl-es-cts-3.2.2 branch can not build (on Linux at least), so I submit this small change to fix the build issue. 

PTAL. Thanks a lot!

