### PR TITLE
Properly handle edge case in GL FP64 tests

### DIFF
--- a/external/openglcts/modules/gl/gl4cGPUShaderFP64Tests.cpp
+++ b/external/openglcts/modules/gl/gl4cGPUShaderFP64Tests.cpp
@@ -15473,7 +15473,9 @@ bool BuiltinFunctionTest::isResultEdgeCase(const functionObject& function_object
 		const glw::GLdouble* argument_1		   = reinterpret_cast<const glw::GLdouble*>(argument_1_bytes);
 		const glw::GLdouble* argument_2		   = reinterpret_cast<const glw::GLdouble*>(argument_2_bytes);
 		const glw::GLdouble* expected_result   = reinterpret_cast<const glw::GLdouble*>(expected_result_src);
+		const glw::GLdouble* actual_result     = reinterpret_cast<const glw::GLdouble*>(result_src);
 		bool				 edge_case_present = false;
+		bool				 recheck 		   = false;
 
 		// verify if there is a mod(a, a) case and prepare new expected result
 		const glw::GLuint		   n_components = Utils::getNumberOfComponentsForVariableType(result_type);
@@ -15481,19 +15483,20 @@ bool BuiltinFunctionTest::isResultEdgeCase(const functionObject& function_object
 		for (glw::GLuint component = 0; component < n_components; ++component)
 		{
 			glw::GLdouble expected_result_component = expected_result[component];
+			glw::GLdouble actual_result_component   = actual_result[component];
 			glw::GLdouble argument_1_component		= argument_1[component];
 			glw::GLdouble argument_2_component		= argument_2[(function_type == FUNCTION_MOD) ? component : 0];
 
 			// if coresponding components of arguments are equal and if component of first argument
 			// and component of result are equal then expected result must be corrected
 			edge_case_present = (m_epsilon > de::abs(argument_1_component - argument_2_component)) &&
-								(m_epsilon > de::abs(argument_1_component - expected_result_component));
-
+								(m_epsilon > de::abs(argument_1_component - actual_result_component));
+			recheck |= edge_case_present;
 			corrected_expected_result[component] = edge_case_present ? argument_1_component : expected_result_component;
 		}
 
 		// recheck test result with corrected expected result
-		return (edge_case_present && compare(result_type, &(corrected_expected_result[0]), result_src));
+		return (recheck && compare(result_type, &(corrected_expected_result[0]), result_src));
 	}
 	default:
 		return false;


### PR DESCRIPTION
c1784ee541a30d700e7caed735353ac109d507c6 attempted to fix #51 already, but
had a few shortcommings:

1. it checked if a edge case is present by comparing the expected and the first argument
   actually the actual result and the first argument have to be compared. The expected result
   was always 0, so this condition was never true;
2. while iterating over the components the edge_case_present was set bac to false if the
   last component wasn't an edge case

fix those issues and make drivers pass the test where floor(a/a) might return 0