### PR TITLE
Add tests for BC-compressed 3D images.

### DIFF
--- a/external/vulkancts/modules/vulkan/texture/vktTextureCompressedFormatTests.cpp
+++ b/external/vulkancts/modules/vulkan/texture/vktTextureCompressedFormatTests.cpp
@@ -161,6 +161,120 @@ tcu::TestStatus Compressed2DTestInstance::iterate (void)
 	return isOk ? tcu::TestStatus::pass("Pass") : tcu::TestStatus::fail("Image verification failed");
 }
 
+struct Compressed3DTestParameters : public Texture3DTestCaseParameters
+{
+										Compressed3DTestParameters	(void);
+	TextureBinding::ImageBackingMode	backingMode;
+};
+
+Compressed3DTestParameters::Compressed3DTestParameters (void)
+	: backingMode(TextureBinding::IMAGE_BACKING_MODE_REGULAR)
+{
+}
+
+class Compressed3DTestInstance : public TestInstance
+{
+public:
+	typedef Compressed3DTestParameters	ParameterType;
+
+										Compressed3DTestInstance	(Context&				context,
+																	 const ParameterType&	testParameters);
+	tcu::TestStatus						iterate						(void);
+
+private:
+										Compressed3DTestInstance	(const Compressed3DTestInstance& other);
+	Compressed3DTestInstance&			operator=					(const Compressed3DTestInstance& other);
+
+	const ParameterType&				m_testParameters;
+	const tcu::CompressedTexFormat		m_compressedFormat;
+	TestTexture3DSp						m_texture;
+	TextureRenderer						m_renderer;
+};
+
+Compressed3DTestInstance::Compressed3DTestInstance (Context&				context,
+													const ParameterType&	testParameters)
+	: TestInstance			(context)
+	, m_testParameters		(testParameters)
+	, m_compressedFormat	(mapVkCompressedFormat(testParameters.format))
+	, m_texture				(TestTexture3DSp(new pipeline::TestTexture3D(m_compressedFormat, testParameters.width, testParameters.height, testParameters.depth)))
+	, m_renderer			(context, testParameters.sampleCount, testParameters.width, testParameters.height)
+{
+	m_renderer.add3DTexture(m_texture, testParameters.backingMode);
+}
+
+tcu::TestStatus Compressed3DTestInstance::iterate (void)
+{
+	tcu::TestLog&					log				= m_context.getTestContext().getLog();
+	const pipeline::TestTexture3D&	texture			= m_renderer.get3DTexture(0);
+	const tcu::TextureFormat		textureFormat	= texture.getTextureFormat();
+	const tcu::TextureFormatInfo	formatInfo		= tcu::getTextureFormatInfo(textureFormat);
+
+	ReferenceParams					sampleParams	(TEXTURETYPE_3D);
+	tcu::Surface					rendered		(m_renderer.getRenderWidth(), m_renderer.getRenderHeight());
+	tcu::Vec3						texCoord[4];
+	const float* const				texCoordPtr = (const float*)&texCoord[0];
+
+	// Setup params for reference.
+	sampleParams.sampler			= util::createSampler(m_testParameters.wrapS, m_testParameters.wrapT, m_testParameters.wrapR, m_testParameters.minFilter, m_testParameters.magFilter);
+	sampleParams.samplerType		= SAMPLERTYPE_FLOAT;
+	sampleParams.lodMode			= LODMODE_EXACT;
+
+	if (isAstcFormat(m_compressedFormat)
+		|| m_compressedFormat == tcu::COMPRESSEDTEXFORMAT_BC4_UNORM_BLOCK
+		|| m_compressedFormat == tcu::COMPRESSEDTEXFORMAT_BC5_UNORM_BLOCK)
+	{
+		sampleParams.colorBias			= tcu::Vec4(0.0f);
+		sampleParams.colorScale			= tcu::Vec4(1.0f);
+	}
+	else if (m_compressedFormat == tcu::COMPRESSEDTEXFORMAT_BC4_SNORM_BLOCK)
+	{
+		sampleParams.colorBias			= tcu::Vec4(0.5f, 0.0f, 0.0f, 0.0f);
+		sampleParams.colorScale			= tcu::Vec4(0.5f, 1.0f, 1.0f, 1.0f);
+	}
+	else if (m_compressedFormat == tcu::COMPRESSEDTEXFORMAT_BC5_SNORM_BLOCK)
+	{
+		sampleParams.colorBias			= tcu::Vec4(0.5f, 0.5f, 0.0f, 0.0f);
+		sampleParams.colorScale			= tcu::Vec4(0.5f, 0.5f, 1.0f, 1.0f);
+	}
+	else
+	{
+		sampleParams.colorBias			= formatInfo.lookupBias;
+		sampleParams.colorScale			= formatInfo.lookupScale;
+	}
+
+	log << TestLog::Message << "Compare reference value = " << sampleParams.ref << TestLog::EndMessage;
+
+	// Compute texture coordinates.
+	{
+		texCoord[0] = tcu::Vec3(0.0f,	0.0f,	0.0f);
+		texCoord[1] = tcu::Vec3(0.0f,	1.0f,	0.5f);
+		texCoord[2] = tcu::Vec3(1.0f,	0.0f,	0.5f);
+		texCoord[3] = tcu::Vec3(1.0f,	1.0f,	1.0f);
+	}
+
+	m_renderer.renderQuad(rendered, 0, texCoordPtr, sampleParams);
+
+	// Compute reference.
+	const tcu::IVec4		formatBitDepth	= getTextureFormatBitDepth(vk::mapVkFormat(VK_FORMAT_R8G8B8A8_UNORM));
+	const tcu::PixelFormat	pixelFormat		(formatBitDepth[0], formatBitDepth[1], formatBitDepth[2], formatBitDepth[3]);
+	tcu::Surface			referenceFrame	(m_renderer.getRenderWidth(), m_renderer.getRenderHeight());
+	sampleTexture(tcu::SurfaceAccess(referenceFrame, pixelFormat), (tcu::Texture3DView)m_texture->getTexture(), texCoordPtr, sampleParams);
+
+	// Compare and log.
+	tcu::RGBA threshold;
+
+	if (isBcBitExactFormat(m_compressedFormat))
+		threshold = tcu::RGBA(1, 1, 1, 1);
+	else if (isBcFormat(m_compressedFormat))
+		threshold = tcu::RGBA(8, 8, 8, 8);
+	else
+		threshold = pixelFormat.getColorThreshold() + tcu::RGBA(2, 2, 2, 2);
+
+	const bool isOk = compareImages(log, referenceFrame, rendered, threshold);
+
+	return isOk ? tcu::TestStatus::pass("Pass") : tcu::TestStatus::fail("Image verification failed");
+}
+
 void populateTextureCompressedFormatTests (tcu::TestCaseGroup* compressedTextureTests)
 {
 	tcu::TestContext&	testCtx	= compressedTextureTests->getTestContext();
@@ -232,11 +346,12 @@ void populateTextureCompressedFormatTests (tcu::TestCaseGroup* compressedTexture
 	static const struct {
 		const int	width;
 		const int	height;
+		const int	depth;
 		const char*	name;
 	} sizes[] =
 	{
-		{ 128, 64, "pot"  },
-		{ 51,  65, "npot" },
+		{ 128, 64, 64, "pot"  },
+		{ 51,  65, 33, "npot" },
 	};
 
 	static const struct {
@@ -265,6 +380,18 @@ void populateTextureCompressedFormatTests (tcu::TestCaseGroup* compressedTexture
 		testParameters.programs.push_back(PROGRAM_2D_FLOAT);
 
 		compressedTextureTests->addChild(new TextureTestCase<Compressed2DTestInstance>(testCtx, (nameBase + "_2d_" + sizes[sizeNdx].name + backingModes[backingNdx].name).c_str(), (formatStr + ", TEXTURETYPE_2D").c_str(), testParameters));
+
+		Compressed3DTestParameters		testParameters3D;
+		testParameters3D.format			= formats[formatNdx].format;
+		testParameters3D.backingMode	= backingModes[backingNdx].backingMode;
+		testParameters3D.width			= sizes[sizeNdx].width;
+		testParameters3D.height			= sizes[sizeNdx].height;
+		testParameters3D.depth			= sizes[sizeNdx].depth;
+		testParameters3D.minFilter		= tcu::Sampler::NEAREST;
+		testParameters3D.magFilter		= tcu::Sampler::NEAREST;
+		testParameters3D.programs.push_back(PROGRAM_3D_FLOAT);
+
+		compressedTextureTests->addChild(new TextureTestCase<Compressed3DTestInstance>(testCtx, (nameBase + "_3d_" + sizes[sizeNdx].name + backingModes[backingNdx].name).c_str(), (formatStr + ", TEXTURETYPE_3D").c_str(), testParameters3D));
 	}
 }
 


### PR DESCRIPTION
This was useful for testing KhronosGroup/MoltenVK#435. Also, the Vulkan spec says
that if BC formats are supported, they must be supported for both 2D
and 3D images. (Should I add these to the mustpass list?)