### PR TITLE
ES: Mark rgb565d0s0ms0 as Android only

### DIFF
--- a/external/openglcts/modules/runner/glcAospMustpassEs.hpp
+++ b/external/openglcts/modules/runner/glcAospMustpassEs.hpp
@@ -37,7 +37,9 @@ static const RunParams aosp_mustpass_es_first_cfg[] = {
 	{ glu::ApiType::es(3, 0), "rotate-reverse-landscape", "rgba8888d24s8ms0", "270", -1, DE_NULL, 256, 256 },
 #endif // DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 0), "multisample", "rgba8888d24s8ms4", "unspecified", -1, DE_NULL, 256, 256 },
+#if DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 0), "565-no-depth-no-stencil", "rgb565d0s0ms0", "unspecified", -1, DE_NULL, 256, 256 },
+#endif // DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 1), "master", "rgba8888d24s8ms0", "unspecified", -1, DE_NULL, 256, 256 },
 #if DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 1), "rotate-portrait", "rgba8888d24s8ms0", "0", -1, DE_NULL, 256, 256 },
@@ -52,7 +54,9 @@ static const RunParams aosp_mustpass_es_first_cfg[] = {
 	{ glu::ApiType::es(3, 1), "rotate-reverse-landscape", "rgba8888d24s8ms0", "270", -1, DE_NULL, 256, 256 },
 #endif // DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 1), "multisample", "rgba8888d24s8ms4", "unspecified", -1, DE_NULL, 256, 256 },
+#if DE_OS == DE_OS_ANDROID
 	{ glu::ApiType::es(3, 1), "565-no-depth-no-stencil", "rgb565d0s0ms0", "unspecified", -1, DE_NULL, 256, 256 },
+#endif // DE_OS == DE_OS_ANDROID
 };
 
 #endif // _GLCAOSPMUSTPASSES_HPP


### PR DESCRIPTION
This prevents the following error from causing
cts-runner failures when testing es3/es31/es32.

```
$ ./cts-runner --type=es3
Running OpenGL ES 3 conformance
No WGL configs enumerated: WGL is not supported on this OS
  found 8 compatible and 32 excluded configs
ERROR: No suitable configuration found for GL config rgb565d0s0ms0 at glcTestRunner.cpp:341
```

Signed-off-by: Robert Foss <robert.foss@collabora.com>