### PR TITLE
Use binding 0 for atomic counter buffers

### DIFF
--- a/modules/gles31/functional/es31fAtomicCounterTests.cpp
+++ b/modules/gles31/functional/es31fAtomicCounterTests.cpp
@@ -196,7 +196,7 @@ string AtomicCounterTest::generateShaderSource (const TestSpec& spec)
 		{
 			case OFFSETTYPE_DEFAULT_AUTO:
 				if (!wroteLayout)
-					src << "layout(binding=1, ";
+					src << "layout(binding=0, ";
 				else
 					src << ", ";
 
@@ -208,7 +208,7 @@ string AtomicCounterTest::generateShaderSource (const TestSpec& spec)
 				DE_ASSERT(spec.atomicCounterCount > 2);
 
 				if (!wroteLayout)
-					src << "layout(binding=1, ";
+					src << "layout(binding=0, ";
 				else
 					src << ", ";
 
@@ -218,7 +218,7 @@ string AtomicCounterTest::generateShaderSource (const TestSpec& spec)
 
 			case OFFSETTYPE_INVALID_DEFAULT:
 				if (!wroteLayout)
-					src << "layout(binding=1, ";
+					src << "layout(binding=0, ";
 				else
 					src << ", ";
 
@@ -260,13 +260,13 @@ string AtomicCounterTest::generateShaderSource (const TestSpec& spec)
 		bool layoutStarted = false;
 
 		if (spec.offsetType == OFFSETTYPE_RESET_DEFAULT && counterNdx == spec.atomicCounterCount/2)
-			src << "layout(binding=1, offset=0) uniform atomic_uint;\n";
+			src << "layout(binding=0, offset=0) uniform atomic_uint;\n";
 
 		switch (spec.bindingType)
 		{
 			case BINDINGTYPE_BASIC:
 				layoutStarted = true;
-				src << "layout(binding=1";
+				src << "layout(binding=0";
 				break;
 
 			case BINDINGTYPE_INVALID:
@@ -968,7 +968,7 @@ TestCase::IterateResult AtomicCounterTest::iterate (void)
 	GLU_EXPECT_NO_ERROR(gl.getError(), "Failed to setup output buffer");
 
 	// Bind atomic counter buffer
-	gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 1, *counterBuffer);
+	gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 0, *counterBuffer);
 	GLU_EXPECT_NO_ERROR(gl.getError(), "Failed to setup atomic counter buffer");
 
 	// Dispath compute

--- a/modules/gles31/functional/es31fSynchronizationTests.cpp
+++ b/modules/gles31/functional/es31fSynchronizationTests.cpp
@@ -2487,7 +2487,7 @@ TestCase::IterateResult ConcurrentAtomicCounterCase::iterate (void)
 			throw tcu::TestError("u_callNdx location was -1");
 
 		gl.bindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, m_intermediateResultBuffer);
-		gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 2, m_counterBuffer);
+		gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 0, m_counterBuffer);
 
 		for (int callNdx = 0; callNdx < m_numCalls; ++callNdx)
 		{
@@ -3062,7 +3062,7 @@ TestCase::IterateResult ConcurrentSSBOAtomicCounterMixedCase::iterate (void)
 			<< tcu::TestLog::EndMessage;
 
 		gl.bindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, m_bufferID);
-		gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 2, m_bufferID);
+		gl.bindBufferBase(GL_ATOMIC_COUNTER_BUFFER, 0, m_bufferID);
 
 		for (int callNdx = 0; callNdx < m_numCalls; ++callNdx)
 		{
@@ -3133,7 +3133,7 @@ std::string ConcurrentSSBOAtomicCounterMixedCase::genAtomicCounterComputeSource 
 	buf	<< "${GLSL_VERSION_DECL}\n"
 		<< "layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;\n"
 		<< "\n"
-		<< "layout (binding = 2, offset = 0) uniform atomic_uint u_counter;\n"
+		<< "layout (binding = 0, offset = 0) uniform atomic_uint u_counter;\n"
 		<< "\n"
 		<< "void main ()\n"
 		<< "{\n"


### PR DESCRIPTION
GLES3.1 has a minimum requirement of one atomic counter buffer binding.
The following tests were binding atomic counter buffers to bindings 1
and 2 respectively:

  dEQP-GLES31.functional.atomic_counter.*
  dEQP-GLES31.functional.synchronization.inter_call.without_memory_barrier.*atomic_counter*

This makes the tests fail on implementations that support the minimum
required number of bindings.

VK-GL-CTS github issue: 156