### PR TITLE
Fix invalid parameter for GLES 2.0

### DIFF
--- a/external/openglcts/modules/common/glcInternalformatTests.cpp
+++ b/external/openglcts/modules/common/glcInternalformatTests.cpp
@@ -707,7 +707,12 @@ tcu::TestNode::IterateResult Texture2DCase::iterate(void)
 		formatMap[GL_LUMINANCE]		  = TextureFormat(GL_LUMINANCE, GL_UNSIGNED_BYTE, GL_LUMINANCE);
 		formatMap[GL_LUMINANCE_ALPHA] = TextureFormat(GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, GL_LUMINANCE_ALPHA);
 		formatMap[GL_DEPTH_COMPONENT] = TextureFormat(GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, GL_DEPTH_COMPONENT);
-		formatMap[GL_DEPTH_STENCIL]   = TextureFormat(GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, GL_DEPTH24_STENCIL8);
+		formatMap[GL_DEPTH_STENCIL] = TextureFormat(GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, GL_DEPTH_STENCIL);
+
+		if (glu::contextSupports(m_context.getRenderContext().getType(), glu::ApiType::es(3, 0)))
+		{
+			formatMap[GL_DEPTH_STENCIL] = TextureFormat(GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, GL_DEPTH24_STENCIL8_OES);
+		}
 	}
 
 	ReferenceFormatMap::iterator formatIterator = formatMap.find(m_testFormat.format);


### PR DESCRIPTION
Test was creating a texture with format of GL_DEPTH_STENCIL and
internalformat of GL_DEPTH24_STENCIL8_OES. In ES 2.0 the format and
internalformat must match.
Added an extra case when running 3.0 or better that does allow different
values for format and internalformat.

Tests:
    KHR-GLES2.core.internalformat.texture2d.rgb_unsigned_byte_rgb8
    KHR-GLES2.core.internalformat.texture2d.rgba_unsigned_byte_rgba8
    KHR-GLES2.core.internalformat.texture2d.depth_stencil_unsigned_int_24_8_depth24_stencil8

Bug #158