### PR TITLE
Fix texture_size_promotion failures with OpenGL 3.1

### DIFF
--- a/external/openglcts/modules/gl/gl3cTextureSizePromotion.cpp
+++ b/external/openglcts/modules/gl/gl3cTextureSizePromotion.cpp
@@ -244,6 +244,18 @@ void FunctionalTest::prepareSourceTexture(TextureInternalFormatDescriptor descri
 
 	if (!isTargetMultisampled(target))
 	{
+		glu::ContextType context_type = m_context.getRenderContext().getType();
+		if (isDepthType(descriptor) && glu::contextSupports(context_type, glu::ApiType::core(3, 1)))
+		{
+			/* 3.1 context may have GL_ARB_compatibility which has
+			 * GL_DEPTH_TEXTURE_MODE set to GL_LUMINANCE by default.
+			 * Set it to GL_RED since we expect depth texture sampling
+			 * to return vec4(depth, 0, 0, 1).
+			 */
+			gl.texParameteri(target, 0x884B, GL_RED);
+			gl.getError();
+		}
+
 		gl.texParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		gl.texParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
@@ -734,8 +746,6 @@ glw::GLuint FunctionalTest::prepareProgram(glw::GLenum target, TextureInternalFo
 			sampler_prefix = "u";
 		}
 	}
-
-	std::string template_verison = "#version 150";
 
 	/* Preprocessing fragment shader source code. */
 	std::string fragment_shader = s_fragment_shader_template;
@@ -1380,7 +1390,7 @@ const FunctionalTest::TextureInternalFormatDescriptor FunctionalTest::s_formats[
 
 const glw::GLuint FunctionalTest::s_formats_size = sizeof(s_formats) / sizeof(s_formats[0]);
 
-const glw::GLchar* FunctionalTest::s_vertex_shader_code = "#version 150\n"
+const glw::GLchar* FunctionalTest::s_vertex_shader_code = "#version 140\n"
 														  "\n"
 														  "void main()\n"
 														  "{\n"
@@ -1402,7 +1412,8 @@ const glw::GLchar* FunctionalTest::s_vertex_shader_code = "#version 150\n"
 														  "}\n";
 
 const glw::GLchar* FunctionalTest::s_fragment_shader_template =
-	"#version 150\n"
+	"#version 140\n"
+	"#extension GL_ARB_texture_multisample : enable\n"
 	"\n"
 	"out TEMPLATE_TYPE result;\n"
 	"\n"


### PR DESCRIPTION
"OpenGL 3.1 with GL_ARB_compatibility" spec, section 3.9.12:
```
  The values of DEPTH_TEXTURE_MODE, TEXTURE_COMPARE_MODE,
  and TEXTURE_COMPARE_FUNC are LUMINANCE, NONE, and LEQUAL
  respectively.
```
In case when OpenGL 3.1 context has GL_ARB_compatibility enabled result for texelFetch of depth texture is `(depth, depth, depth, 1)` instead of `(depth, 0, 0, 1)`. Therefore we should set GL_DEPTH_TEXTURE_MODE to GL_RED.

Change shaders' glsl version to 140 to match OpenGL 3.1