### PR TITLE
Clear GL_ERROR from unsupported samples

### DIFF
--- a/modules/gles31/functional/es31fShaderHelperInvocationTests.cpp
+++ b/modules/gles31/functional/es31fShaderHelperInvocationTests.cpp
@@ -235,7 +235,11 @@ FboHelper::FboHelper (const glu::RenderContext& renderCtx, int width, int height
 	gl.framebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, *m_colorbuffer);
 
 	if (m_numSamples > maxSamples && gl.checkFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+	{
+		// Clear GL_INVALID_VALUE error from glRenderbufferStorageMultisample() w/ invalid m_numSamples
+		gl.getError();
 		throw tcu::NotSupportedError("Sample count exceeds GL_MAX_SAMPLES");
+	}
 
 	TCU_CHECK(gl.checkFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 


### PR DESCRIPTION
When the gl_HelperInvocation attempt to run with an unsupported number of samples,
the test is correctly passed as "Not Supported."
However, if you run multiple tests in sequence that are Not Supported, the first one will
leave a valid GL_ERROR value that then causes the next test to fail.
This fix clears any error before throwing unsupported exception.

Fixes #178