### PR TITLE
Fix a typo for Linux run of deqp-vk

### DIFF
--- a/external/vulkancts/README.md
+++ b/external/vulkancts/README.md
@@ -177,7 +177,7 @@ Test log will be written into TestResults.qpa
 ### Linux
 
 	cd <builddir>/external/vulkancts/modules/vulkan
-	./deqp-vk --deqp-vk-caselist-file=...
+	./deqp-vk --deqp-caselist-file=...
 
 ### Android
 


### PR DESCRIPTION
Unrecognized command line option
'--deqp-vk-caselist-file=/home/user/VK-GL-CTS/external/vulkancts/mustpass/master/vk-default.txt'

It should be `--deqp-caselist-file`