### PR TITLE
Cast pointer to deUintptr instead of long

### DIFF
--- a/external/openglcts/modules/gles31/es31cShaderAtomicCountersTests.cpp
+++ b/external/openglcts/modules/gles31/es31cShaderAtomicCountersTests.cpp
@@ -722,8 +722,8 @@ public:
 		if (ptr != map_pointer_)
 		{
 			m_context.getTestContext().getLog()
-				<< tcu::TestLog::Message << "BUFFER_MAP_POINTER is " << reinterpret_cast<uintptr_t>(static_cast<int*>(ptr))
-				<< " should be " << reinterpret_cast<uintptr_t>(static_cast<int*>(map_pointer_)) << tcu::TestLog::EndMessage;
+				<< tcu::TestLog::Message << "BUFFER_MAP_POINTER is " << reinterpret_cast<deUintptr>(static_cast<int*>(ptr))
+				<< " should be " << reinterpret_cast<deUintptr>(static_cast<int*>(map_pointer_)) << tcu::TestLog::EndMessage;
 			return ERROR;
 		}
 		return NO_ERROR;

--- a/external/openglcts/modules/gles31/es31cShaderAtomicCountersTests.cpp
+++ b/external/openglcts/modules/gles31/es31cShaderAtomicCountersTests.cpp
@@ -722,8 +722,8 @@ public:
 		if (ptr != map_pointer_)
 		{
 			m_context.getTestContext().getLog()
-				<< tcu::TestLog::Message << "BUFFER_MAP_POINTER is " << reinterpret_cast<long>(static_cast<int*>(ptr))
-				<< " should be " << reinterpret_cast<long>(static_cast<int*>(map_pointer_)) << tcu::TestLog::EndMessage;
+				<< tcu::TestLog::Message << "BUFFER_MAP_POINTER is " << reinterpret_cast<uintptr_t>(static_cast<int*>(ptr))
+				<< " should be " << reinterpret_cast<uintptr_t>(static_cast<int*>(map_pointer_)) << tcu::TestLog::EndMessage;
 			return ERROR;
 		}
 		return NO_ERROR;


### PR DESCRIPTION
long may not be able to fit a pointer, and C++ does not allow casting
from a pointer to a smaller int.