### PR TITLE
Fix broken layout binding tests

### DIFF
--- a/external/openglcts/modules/gles31/es31cLayoutBindingTests.cpp
+++ b/external/openglcts/modules/gles31/es31cLayoutBindingTests.cpp
@@ -2476,9 +2476,9 @@ private:
 		{
 			bool		 passed = true;
 			StringStream s;
-			s << buildAccess(getDefaultUniformName()) << ";\n";
-			s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
-			s << "+" << buildAccess(getDefaultUniformName(2)) << ";\n";
+			s << buildAccess(getDefaultUniformName()) << "\n";
+			s << "+" << buildAccess(getDefaultUniformName(1)) << "\n";
+			s << "+" << buildAccess(getDefaultUniformName(2)) << "\n";
 			s << "+" << buildAccess(getDefaultUniformName(3)) << ";\n";
 			setTemplateParam("UNIFORM_ACCESS", s.str());
 
@@ -2571,10 +2571,16 @@ private:
 				bool passed = true;
 
 				StringStream s;
-				s << buildAccess(getDefaultUniformName()) << ";\n";
-				s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+				s << buildAccess(getDefaultUniformName()) << "\n";
 				if (pass)
+				{
+					s << "+" << buildAccess(getDefaultUniformName(1)) << "\n";
 					s << "+" << buildAccess(getDefaultUniformName(2)) << ";\n";
+				}
+				else
+				{
+					s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+				}
 				setTemplateParam("UNIFORM_ACCESS", s.str());
 
 				s.reset();
@@ -2613,10 +2619,16 @@ private:
 				bool passed = true;
 
 				StringStream s;
-				s << buildAccess(getDefaultUniformName()) << ";\n";
-				s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+				s << buildAccess(getDefaultUniformName()) << "\n";
 				if (pass)
+				{
+					s << "+" << buildAccess(getDefaultUniformName(1)) << "\n";
 					s << "+" << buildAccess(getDefaultUniformName(2)) << ";\n";
+				}
+				else
+				{
+					s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+				}
 				setTemplateParam("UNIFORM_ACCESS", s.str());
 
 				s.reset();
@@ -2687,9 +2699,9 @@ private:
 		{
 			bool		 passed = true;
 			StringStream s;
-			s << buildAccess(getDefaultUniformName()) << ";\n";
-			s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
-			s << "+" << buildAccess(getDefaultUniformName(2)) << ";\n";
+			s << buildAccess(getDefaultUniformName()) << "\n";
+			s << "+" << buildAccess(getDefaultUniformName(1)) << "\n";
+			s << "+" << buildAccess(getDefaultUniformName(2)) << "\n";
 			s << "+" << buildAccess(getDefaultUniformName(3)) << ";\n";
 			setTemplateParam("UNIFORM_ACCESS", s.str());
 
@@ -2780,9 +2792,16 @@ private:
 			bool passed = true;
 
 			StringStream s;
-			s << buildAccess(getDefaultUniformName()) << ";\n";
+
 			if (pass)
+			{
+				s << buildAccess(getDefaultUniformName()) << "\n";
 				s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+			}
+			else
+			{
+				s << buildAccess(getDefaultUniformName()) << ";\n";
+			}
 			setTemplateParam("UNIFORM_ACCESS", s.str());
 
 			s.reset();
@@ -2817,9 +2836,14 @@ private:
 			bool passed = true;
 
 			StringStream s;
-			s << buildAccess(getDefaultUniformName()) << ";\n";
-			if (pass)
+			if (pass) {
+				s << buildAccess(getDefaultUniformName()) << "\n";
 				s << "+" << buildAccess(getDefaultUniformName(1)) << ";\n";
+			}
+			else
+			{
+				s << buildAccess(getDefaultUniformName()) << ";\n";
+			}
 			setTemplateParam("UNIFORM_ACCESS", s.str());
 
 			s.reset();


### PR DESCRIPTION
Some of the shaders being generated would fail to compile due
to a misplaced ;

An example of the code being gererated is as follows:

  fragColor = vec4(float(atomicCounter(atomic0)), 1.0, 0.0, 1.0);
  +vec4(float(atomicCounter(atomic1)), 1.0, 0.0, 1.0);
  +vec4(float(atomicCounter(atomic2)), 1.0, 0.0, 1.0);
  +vec4(float(atomicCounter(atomic3)), 1.0, 0.0, 1.0);

So we had compile tests checking for failures and passing but for
the wrong reason.