### PR TITLE
Fix some egl robustness tests

### DIFF
--- a/modules/egl/teglRobustnessTests.cpp
+++ b/modules/egl/teglRobustnessTests.cpp
@@ -1108,7 +1108,7 @@ std::string ShadersOOB::genVertexShader (const std::string& shaderDecl, const st
 								<<	shaderDecl << "\n"
 								<<	"void main (void)\n"
 								<<	"{\n"
-								<<	"	highp vec4 color;\n"
+								<<	"	highp vec4 color = vec4(0.0f);\n"
 								<<	shaderBody << "\n"
 								<<	"	v_color = color;\n"
 								<<	"	gl_Position = a_position;\n"


### PR DESCRIPTION
Because the values of color were initially undefined an optimised
compiler can simply set all components of the vector to the value
being assigned to color[u_index] and eventually eliminate color and
u_index completely.

To avoid this we initialise color.