### PR TITLE
Add tests for XFB output of matrices/arrays/structs with explicit location (GL_ARB_enhanced_layouts)

### DIFF
--- a/external/openglcts/modules/gl/gl4cEnhancedLayoutsTests.hpp
+++ b/external/openglcts/modules/gl/gl4cEnhancedLayoutsTests.hpp
@@ -4771,6 +4771,133 @@ private:
 	std::vector<testCase> m_test_cases;
 };
 
+/** Implementation of test XFBExplicitLocationTest. Description follows:
+ *
+ * Test verifies that explicit location on matrices and arrays does not impact xfb output.
+ *
+ * Test following code snippet:
+ *
+ *     layout (location = 0, xfb_offset = 0) out vec2 goku[3];
+ *
+ * Is expected to have the same output as:
+ *
+ *     layout (xfb_offset = 0) out vec2 goku[3];
+ *
+ * While explicit location does impact varyings layout of matrices and arrays, see
+ * Ref. GLSL 4.60, Section 4.4.2. "Output Layout Qualifiers" - it shall not impact
+ * xfb output.
+ *
+ * Test all shader stages.
+ **/
+class XFBExplicitLocationTest : public BufferTestBase
+{
+public:
+	XFBExplicitLocationTest(deqp::Context& context);
+	~XFBExplicitLocationTest()
+	{
+	}
+
+protected:
+	/* Protected methods */
+	using BufferTestBase::executeDrawCall;
+
+	virtual bool executeDrawCall(bool tesEnabled, glw::GLuint test_case_index);
+	virtual void getBufferDescriptors(glw::GLuint test_case_index, bufferDescriptor::Vector& out_descriptors);
+
+	virtual void getShaderBody(glw::GLuint test_case_index, Utils::Shader::STAGES stage, std::string& out_assignments,
+							   std::string& out_calculations);
+
+	virtual void getShaderInterface(glw::GLuint test_case_index, Utils::Shader::STAGES stage,
+									std::string& out_interface);
+
+	virtual std::string getShaderSource(glw::GLuint test_case_index, Utils::Shader::STAGES stage);
+
+	virtual std::string getTestCaseName(glw::GLuint test_case_index);
+	virtual glw::GLuint getTestCaseNumber();
+	virtual void		testInit();
+
+private:
+	/* Private types */
+	struct testCase
+	{
+		Utils::Shader::STAGES	m_stage;
+		Utils::Type				m_type;
+		glw::GLuint				m_array_size;
+	};
+
+	/* Private fields */
+	std::vector<testCase> m_test_cases;
+};
+
+/** Implementation of test XFBExplicitLocationStructTest. Description follows:
+ *
+ * Test verifies that explicit location on struct does not impact xfb output.
+ *
+ * Test following code snippet:
+ *     struct TestStruct {
+ *        float a;
+ *        double b;
+ *      };
+ *
+ *     layout (location = 0, xfb_offset = 0) flat out TestStruct goku;
+ *
+ * Is expected to have the same output as:
+ *
+ *     layout (xfb_offset = 0) flat out TestStruct goku;
+ *
+ * While explicit location does impact varyings layout of structs, see
+ * Ref. GLSL 4.60, Section 4.4.2. "Output Layout Qualifiers" - it shall not impact
+ * xfb output.
+ *
+ * Test all shader stages.
+ **/
+class XFBExplicitLocationStructTest : public BufferTestBase
+{
+public:
+	XFBExplicitLocationStructTest(deqp::Context& context);
+	~XFBExplicitLocationStructTest()
+	{
+	}
+
+protected:
+	/* Protected methods */
+	using BufferTestBase::executeDrawCall;
+
+	virtual bool executeDrawCall(bool tesEnabled, glw::GLuint test_case_index);
+	virtual void getBufferDescriptors(glw::GLuint test_case_index, bufferDescriptor::Vector& out_descriptors);
+
+	virtual void getShaderBody(glw::GLuint test_case_index, Utils::Shader::STAGES stage, std::string& out_assignments,
+							   std::string& out_calculations);
+
+	virtual void getShaderInterface(glw::GLuint test_case_index, Utils::Shader::STAGES stage,
+									std::string& out_interface);
+
+	virtual std::string getShaderSource(glw::GLuint test_case_index, Utils::Shader::STAGES stage);
+
+	virtual std::string getTestCaseName(glw::GLuint test_case_index);
+	virtual glw::GLuint getTestCaseNumber();
+	virtual void		testInit();
+
+private:
+	/* Private types */
+
+	struct testType
+	{
+		Utils::Type	m_type;
+		glw::GLuint	m_array_size;
+	};
+
+	struct testCase
+	{
+		Utils::Shader::STAGES		m_stage;
+		std::vector<testType>		m_types;
+		bool						m_nested_struct;
+	};
+
+	/* Private fields */
+	std::vector<testCase> m_test_cases;
+};
+
 } /* EnhancedLayouts namespace */
 
 /** Group class for Shader Language 420Pack conformance tests */


### PR DESCRIPTION
### Intent

Explicit location on output variables may change[1] how they are located in memory - which may affect how they are handled for transform feedback; at least this is true for Mesa drivers, and its reasonable to assume that other drivers have something similar. 

In addition, automatic calculation of xfb offsets and strides, especially with 64bit types and their alignment rules[2] - doesn't have good test coverage. 

[1] Per GL_ARB_enhanced_layouts if explicit location is set for varying, each struct member, array element and matrix row will take separate location. With GL_ARB_gpu_shader_fp64/GL_ARB_gpu_shader_int64 they may take two locations.

[2] Captured double-precision variables should be aligned to 8 bytes per GL_ARB_gpu_shader_fp64:
```
 "If any variable captured in transform feedback has double-precision
 components, the practical requirements for defined behavior are:
     ...
 (c) each double-precision variable captured must be aligned to a
     multiple of eight bytes relative to the beginning of a vertex."
```
### Details

New tests:
- `KHR-GL44.enhanced_layouts.xfb_explicit_location`
- `KHR-GL44.enhanced_layouts.xfb_struct_explicit_location`

<details>
<summary>Shader archetypes present in the tests (click me)</summary>

`KHR-GL44.enhanced_layouts.xfb_explicit_location`:
```
layout (location = 0, xfb_offset = 0) flat out mat3 goku;

```

```
layout (location = 0, xfb_offset = 0) flat out mat3[2] goku;

```

```
layout (location = 0, xfb_offset = 0) flat out double[2] goku;

```

`KHR-GL44.enhanced_layouts.xfb_struct_explicit_location`:

```
struct TestStruct {
    float a;
    dvec3 b;
    float c;
    double d;
};

layout (location = 0, xfb_offset = 0) flat out TestStruct goku;

```

```
struct TestStruct {
    float a;
    dvec3 b;
    float c;
    double d;
};

struct OuterStruct {
    TestStruct inner_struct_a;
    TestStruct inner_struct_b;
};

layout (location = 0, xfb_offset = 0) flat out OuterStruct goku;

```
    ```
    struct TestStruct {
        float a[3];
        dvec3 b[2];
        float c[1];
        double d;
    };
    
    layout (location = 0, xfb_offset = 0) flat out TestStruct goku;
    ```
</details>

### Results on different drivers

| Driver | Results |
| ------ | ------ |
| Mesa | `KHR-GL44.enhanced_layouts.xfb_explicit_location` - fails :x: <br> `KHR-GL44.enhanced_layouts.xfb_struct_explicit_location` - fails :x: <br> (Without `location=0`)`KHR-GL44.enhanced_layouts.xfb_explicit_location` - passes :heavy_check_mark: <br> (Without `location=0`)`KHR-GL44.enhanced_layouts.xfb_struct_explicit_location` - fails :x: |
| Intel (Proprietary) | `KHR-GL44.enhanced_layouts.xfb_explicit_location` - passes :heavy_check_mark: <br> `KHR-GL44.enhanced_layouts.xfb_struct_explicit_location` - fails :x: :<br> `Link failure: Variable "goku.b"; xfb_offset is not aligned to 8.` |
| NVIDIA (Proprietary) <br>418.67 and 435.21| `KHR-GL44.enhanced_layouts.xfb_explicit_location` - fails :x: :  <br>   `   error: goku with xfb_offset 0 is outside the xfb_stride 8 for this buffer.`  <br><br> `KHR-GL44.enhanced_layouts.xfb_struct_explicit_location` - passes :heavy_check_mark: <br> |


<details>
<summary>Shader which NVIDIA fails to compile (click me)</summary>

```
#version 430 core
#extension GL_ARB_enhanced_layouts : require

layout(isolines, point_mode) in;

layout (location = 0, xfb_offset = 0) flat out double goku[3];

layout(std140, binding = 0) uniform Goku {
    double uni_goku[3];
};

void main()
{

    goku = uni_goku;
}

//error: goku with xfb_offset 0 is outside the xfb_stride 8 for this buffer.
```

</details>

<details>
<summary>Shader which proprietary Intel fails to compile (click me)</summary>

```
#version 430 core
#extension GL_ARB_enhanced_layouts : require

struct TestStruct {
   float a;
   double b;
};
layout (location = 0, xfb_offset = 0) flat out TestStruct goku;

layout(std140, binding = 0) uniform Goku {
    TestStruct uni_goku;
};

void main()
{

    goku = uni_goku;
}

// Link failure: Variable "goku.b"; xfb_offset is not aligned to 8
```
</details>


Note: all tests which fail to compile could be compiled without errors with `glslang`.

### Additional considerations

- While the tests have explicit location - it is reasonable to also test without explicit location. I'm not sure if it would fit `KHR-GL44.enhanced_layouts.*` tests.
