### PR TITLE
Fix loading glRenderbufferStorageMultisampleEXT

### DIFF
--- a/framework/opengl/wrapper/glwInitExtES.inl
+++ b/framework/opengl/wrapper/glwInitExtES.inl
@@ -122,7 +122,7 @@ if (de::contains(extSet, "GL_EXT_texture_border_clamp"))
 if (de::contains(extSet, "GL_EXT_multisampled_render_to_texture"))
 {
 	gl->framebufferTexture2DMultisampleEXT	= (glFramebufferTexture2DMultisampleEXTFunc)	loader->get("glFramebufferTexture2DMultisampleEXT");
-	gl->renderbufferStorageMultisample		= (glRenderbufferStorageMultisampleFunc)		loader->get("glRenderbufferStorageMultisampleEXT");
+	gl->renderbufferStorageMultisampleEXT	= (glRenderbufferStorageMultisampleEXTFunc)		loader->get("glRenderbufferStorageMultisampleEXT");
 }
 
 if (de::contains(extSet, "GL_EXT_debug_marker"))

--- a/scripts/opengl/gen_ext_init.py
+++ b/scripts/opengl/gen_ext_init.py
@@ -53,7 +53,8 @@ def genExtensions (registry, iface, api):
 		yield "{"
 
 		def genInit (command):
-			ifaceName = command.alias.name if command.alias else command.name
+			useAlias = command.alias and not (extName, command.name) in ALIASING_EXCEPTIONS
+			ifaceName = command.alias.name if useAlias else command.name
 			return "gl->%s\t= (%s)\tloader->get(\"%s\");" % (
 				getFunctionMemberName(ifaceName),
 				getFunctionTypeName(ifaceName),

--- a/scripts/opengl/src_util.py
+++ b/scripts/opengl/src_util.py
@@ -147,7 +147,7 @@ ALIASING_EXCEPTIONS = [
 	# registry insists that this aliases glRenderbufferStorageMultisample,
 	# and from a desktop GL / GLX perspective it *must*, but for ES they are
 	# unfortunately separate functions with different semantics.
-	'glRenderbufferStorageMultisampleEXT',
+	('GL_EXT_multisampled_render_to_texture', 'glRenderbufferStorageMultisampleEXT'),
 ]
 
 def getGLRegistry ():
@@ -180,7 +180,7 @@ def getHybridInterface (stripAliasedExtCommands = True):
 		strippedCmds = []
 
 		for command in iface.commands:
-			if command.alias == None or command.name in ALIASING_EXCEPTIONS:
+			if command.alias == None or (extension, command.name) in ALIASING_EXCEPTIONS:
 				strippedCmds.append(command)
 
 		iface.commands = strippedCmds


### PR DESCRIPTION
This entry point is aliased with glRenderbufferStorageMultisampled,
which is true on desktop, but not on GLES where it belongs to the
never-promoted GL_EXT_multisampled_render_to_texture.

This change uses an alias-exception mechanism used elsewhere in script
generation to correct loading this entry point.

Fixes: KhronosGroup/OpenGL-Registry#413