### PR TITLE
Lower precision required for texture-lookups

### DIFF
--- a/external/openglcts/modules/common/glcNearestEdgeTests.cpp
+++ b/external/openglcts/modules/common/glcNearestEdgeTests.cpp
@@ -42,6 +42,7 @@
 #include <map>
 #include <algorithm>
 #include <memory>
+#include <cmath>
 
 namespace glcts
 {
@@ -285,8 +286,9 @@ void NearestEdgeTestCase::renderQuad ()
 
 	// Apply offset of almost half a texel to the texture coordinates.
 	DE_ASSERT(m_offsetSign == 1.0f || m_offsetSign == -1.0f);
-	const float offsetWidth		= 0.499f / static_cast<float>(m_width);
-	const float offsetHeight	= 0.499f / static_cast<float>(m_height);
+	const float offset			= 0.5f - pow(2.0f, -8.0f);
+	const float offsetWidth		= offset / static_cast<float>(m_width);
+	const float offsetHeight	= offset / static_cast<float>(m_height);
 
 	minU += m_offsetSign * offsetWidth;
 	maxU += m_offsetSign * offsetWidth;


### PR DESCRIPTION
The KHR-GL33.nearest_edge.offset_right test uses an offset of 0.499 to
avoid sampling to close to the edge for rounding issues. This means that
texture sampling requires 9 or more bits of fractional precision. But
some hardware only provides 8 bits of precision, which is what D3D12
requires.

So let's instead calculate this value a bit more carefully, as follows:

0.5 - 2^-8

Components: OpenGL

Affects tests:
KHR-GL33.nearest_edge.offset_right

Fixes: https://github.com/KhronosGroup/VK-GL-CTS/issues/225