### PR TITLE
Use correct image aspect according to format

### DIFF
--- a/external/vulkancts/modules/vulkan/renderpass/vktRenderPassDepthStencilResolveTests.cpp
+++ b/external/vulkancts/modules/vulkan/renderpass/vktRenderPassDepthStencilResolveTests.cpp
@@ -474,7 +474,8 @@ Move<VkRenderPass> DepthStencilResolveTest::createRenderPass (VkFormat vkformat)
 	{
 		if (m_config.verifyBuffer == VB_DEPTH)
 		{
-			layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+			const tcu::TextureFormat format (mapVkFormat(vkformat));
+			layout = tcu::hasStencilComponent(format.order)	? layout : VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
 			stencilLayout.stencilLayout = VK_IMAGE_LAYOUT_GENERAL;
 			finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 			stencilFinalLayout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR; // This aspect should be unused.


### PR DESCRIPTION
When separate depth stencil layout feature is enabled, either we should
have separate layouts available or valid layout for both aspects.

Currently for format with both depth and stencil aspect, for depth test,
we pass only depth layout, instead of that we should pass a valid layout
for both aspects.

Components: Vulkan

Affects Tests:
dEQP-VK.renderpass2.depth_stencil_resolve.*separate_layouts.*

Fixes: https://github.com/KhronosGroup/VK-GL-CTS/issues/230
