### PR TITLE
Fix missing TEXTURE_VALID for EXT_texture_rg

### DIFF
--- a/modules/glshared/glsFboCompletenessTests.cpp
+++ b/modules/glshared/glsFboCompletenessTests.cpp
@@ -267,7 +267,7 @@ static const FormatExtEntry s_esExtFormats[] =
 	},
 	{
 		"GL_EXT_texture_rg",
-		(deUint32)(REQUIRED_RENDERABLE | COLOR_RENDERABLE | RENDERBUFFER_VALID),
+		(deUint32)(REQUIRED_RENDERABLE | COLOR_RENDERABLE | RENDERBUFFER_VALID | TEXTURE_VALID),
 		GLS_ARRAY_RANGE(s_extTextureRgRboFormats)
 	},
 	// These are not specified to be color-renderable, but the wording is


### PR DESCRIPTION
EXT_texture_rg is based on GLES 2.0 and allows GL_R8 and GL_RG8 to be used as texture formats.
Without this fix, GLES 2.0 drivers with EXT_texture_rg report:
  Unsupported texture format * requires any of the extensions or combinations: - GLES3 compatible context

Affects:
  dEQP-GLES2.functional.fbo.completeness.renderable.texture.color0.r8
  dEQP-GLES2.functional.fbo.completeness.renderable.texture.color0.rg8

I noticed this while trying to enable RG texture formats for the mesa lima driver at https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/8549#note_769031