### PR TITLE
Fix missing barrier in texture buffer test

### DIFF
--- a/external/openglcts/modules/glesext/texture_buffer/esextcTextureBufferOperations.cpp
+++ b/external/openglcts/modules/glesext/texture_buffer/esextcTextureBufferOperations.cpp
@@ -1230,6 +1230,8 @@ void TextureBufferOperationsViaTransformFeedback::initializeBufferObjectData()
 
 	gl.useProgram(0);
 
+	gl.memoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
 	m_position_location = -1;
 }
 


### PR DESCRIPTION
Affects:

    KHR-GLES31.core.texture_buffer.texture_buffer_operations_transform_feedback

The test does:

- Draw with transform feedback
- Dispatch using the same buffer as imageBuffer

This is a WaR hazard that needs a glMemoryBarrier.

Signed-off-by: Shahbaz Youssefi <shabbyx@gmail.com>