### PR TITLE
Disable explicit location tests for `arrayed` block members

### DIFF
--- a/modules/gles31/functional/es31fProgramInterfaceQueryTests.cpp
+++ b/modules/gles31/functional/es31fProgramInterfaceQueryTests.cpp
@@ -5446,6 +5446,8 @@ static void generateProgramInputLocationBlockContents (Context& context, const R
 																	: (parentStructure);
 	const glu::ShaderType						firstStage		= getShaderMaskFirstStage(presentShadersMask);
 
+	const bool									inBlockArray	= DE_TRUE == deStringEqual("block_array", targetGroup->getName());
+
 	if (firstStage == glu::SHADERTYPE_VERTEX)
 	{
 		// .var
@@ -5468,6 +5470,7 @@ static void generateProgramInputLocationBlockContents (Context& context, const R
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_INPUT, PROGRAMRESOURCEPROP_LOCATION), "var"));
 		}
 		// .var_explicit_location
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(input, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr variable	(new ResourceDefinition::Variable(layout, glu::TYPE_FLOAT_VEC4));
@@ -5480,6 +5483,7 @@ static void generateProgramInputLocationBlockContents (Context& context, const R
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_INPUT, PROGRAMRESOURCEPROP_LOCATION), "var_struct"));
 		}
 		// .var_struct_explicit_location
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(input, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr structMbr	(new ResourceDefinition::StructMember(layout));
@@ -5493,6 +5497,7 @@ static void generateProgramInputLocationBlockContents (Context& context, const R
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_INPUT, PROGRAMRESOURCEPROP_LOCATION), "var_array"));
 		}
 		// .var_array_explicit_location
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(input, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr arrayElem	(new ResourceDefinition::ArrayElement(layout));
@@ -5590,13 +5595,14 @@ static void generateProgramInputLocationBlockContents (Context& context, const R
 
 static void generateProgramOutputLocationBlockContents (Context& context, const ResourceDefinition::Node::SharedPtr& parentStructure, tcu::TestCaseGroup* targetGroup, deUint32 presentShadersMask, bool isGL45)
 {
+	DE_UNREF(isGL45);
 	const bool									inDefaultBlock	= parentStructure->getType() == ResourceDefinition::Node::TYPE_DEFAULT_BLOCK;
 	const ResourceDefinition::Node::SharedPtr	output			= (inDefaultBlock)
 																	? (ResourceDefinition::Node::SharedPtr(new ResourceDefinition::StorageQualifier(parentStructure, glu::STORAGE_OUT)))
 																	: (parentStructure);
 	const glu::ShaderType						lastStage		= getShaderMaskLastStage(presentShadersMask);
 
-	const bool									inBlockArray	= 0 == deStringEqual("block_array", targetGroup->getName());
+	const bool									inBlockArray	= DE_TRUE == deStringEqual("block_array", targetGroup->getName());
 
 	if (lastStage == glu::SHADERTYPE_VERTEX						||
 		lastStage == glu::SHADERTYPE_GEOMETRY					||
@@ -5609,7 +5615,7 @@ static void generateProgramOutputLocationBlockContents (Context& context, const 
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_OUTPUT, PROGRAMRESOURCEPROP_LOCATION), "var"));
 		}
 		// .var_explicit_location
-		if (!(isGL45 && inBlockArray))
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(output, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr variable	(new ResourceDefinition::Variable(layout, glu::TYPE_FLOAT_VEC4));
@@ -5622,7 +5628,7 @@ static void generateProgramOutputLocationBlockContents (Context& context, const 
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_OUTPUT, PROGRAMRESOURCEPROP_LOCATION), "var_struct"));
 		}
 		// .var_struct_explicit_location
-		if (!(isGL45 && inBlockArray))
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(output, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr structMbr	(new ResourceDefinition::StructMember(layout));
@@ -5636,7 +5642,7 @@ static void generateProgramOutputLocationBlockContents (Context& context, const 
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_OUTPUT, PROGRAMRESOURCEPROP_LOCATION), "var_array"));
 		}
 		// .var_array_explicit_location
-		if (!(isGL45 && inBlockArray))
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(output, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr arrayElem	(new ResourceDefinition::ArrayElement(layout));
@@ -5652,7 +5658,7 @@ static void generateProgramOutputLocationBlockContents (Context& context, const 
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_OUTPUT, PROGRAMRESOURCEPROP_LOCATION), "var"));
 		}
 		// .var_explicit_location
-		if (!(isGL45 && inBlockArray))
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(output, glu::Layout(2)));
 			const ResourceDefinition::Node::SharedPtr variable	(new ResourceDefinition::Variable(layout, glu::TYPE_FLOAT_VEC4));
@@ -5665,7 +5671,7 @@ static void generateProgramOutputLocationBlockContents (Context& context, const 
 			targetGroup->addChild(new ResourceTestCase(context, variable, ProgramResourceQueryTestTarget(PROGRAMINTERFACE_PROGRAM_OUTPUT, PROGRAMRESOURCEPROP_LOCATION), "var_array"));
 		}
 		// .var_array_explicit_location
-		if (!(isGL45 && inBlockArray))
+		if (!inBlockArray)
 		{
 			const ResourceDefinition::Node::SharedPtr layout	(new ResourceDefinition::LayoutQualifier(output, glu::Layout(1)));
 			const ResourceDefinition::Node::SharedPtr arrayElem	(new ResourceDefinition::ArrayElement(layout));


### PR DESCRIPTION
According to the OpenGL 4.5 and Open GLES 3.2 specs these tests
aren't correct:

From Section 4.4.1 (Input Layout Qualifiers) of the GLSL 4.50 spec:
```
  "For some blocks declared as arrays, the location can only be applied
   at the block level: When a block is declared as an array where
   additional locations are needed for each member for each block array
   element, it is a compile-time error to specify locations on the block
   members. That is, when locations would be under specified by applying
   them on block members, they are not allowed on block members. For
   arrayed interfaces (those generally having an extra level of
   arrayness due to interface expansion), the outer array is stripped
   before applying this rule"
```
From Section 4.4.1 (Input Layout Qualifiers) of the GLSL ES 3.20 spec
```
  "If an input is declared as an array of blocks, excluding per-vertex-arrays
   as required for tessellation, it is an error to declare a member of
   the block with a location qualifier"
```
From Section 1.1.3 (Changes from GLSL ES 3.2 revision 3) of the GLSL ES 3.20 spec:
 `"Arrayed blocks cannot have layout location qualifiers on members"`

Here is commit related to it https://github.com/KhronosGroup/VK-GL-CTS/commit/b1e32845c7a95cf2f4b5cd59f7ddaa3c655da626
```
# Khronos bug 15678, internal 27834911
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.out.block_array.var_array_explicit_location
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.out.block_array.var_explicit_location
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.out.block_array.var_struct_explicit_location
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.patch_out.block_array.var_array_explicit_location
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.patch_out.block_array.var_explicit_location
dEQP-GLES31.functional.program_interface_query.program_output.location.interface_blocks.patch_out.block_array.var_struct_explicit_location

dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.in.block_array.var_array_explicit_location
dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.in.block_array.var_explicit_location
dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.in.block_array.var_struct_explicit_location
dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.patch_in.block_array.var_array_explicit_location
dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.patch_in.block_array.var_explicit_location
dEQP-GLES31.functional.program_interface_query.program_input.location.interface_blocks.patch_in.block_array.var_struct_explicit_location
```
Signed-off-by: Andrii Simiklit <andrii.simiklit@globallogic.com>