### PR TITLE
WIP: fix rectangular line tests

### DIFF
--- a/external/vulkancts/modules/vulkan/rasterization/vktRasterizationTests.cpp
+++ b/external/vulkancts/modules/vulkan/rasterization/vktRasterizationTests.cpp
@@ -1414,6 +1414,8 @@ bool BaseLineTestInstance::compareAndVerify (std::vector<LineSceneSpec::SceneLin
 	scene.stipplePattern = getLineStippleEnable() ? lineStipplePattern : 0xFFFF;
 	scene.isStrip = m_primitiveTopology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
 	scene.isSmooth = m_lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT;
+	scene.isRectangular = m_lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT ||
+	                      m_lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT;
 
 	// Choose verification mode. Smooth lines assume mostly over-rasterization (bloated lines with a falloff).
 	// Stippled lines lose some precision across segments in a strip, so need a weaker threshold than normal

--- a/framework/common/tcuRasterizationVerifier.cpp
+++ b/framework/common/tcuRasterizationVerifier.cpp
@@ -955,7 +955,7 @@ bool verifyMultisampleLineGroupRasterization (const tcu::Surface&						surface,
 		};
 
 		const tcu::Vec2 lineDir			= tcu::normalize(lineScreenSpace[1] - lineScreenSpace[0]);
-		const tcu::Vec2 lineNormalDir	= strictMode ? tcu::Vec2(lineDir.y(), -lineDir.x())
+		const tcu::Vec2 lineNormalDir	= (strictMode || scene.isRectangular) ? tcu::Vec2(lineDir.y(), -lineDir.x())
 										: isLineXMajor(lineScreenSpace[0], lineScreenSpace[1]) ? tcu::Vec2(0.0f, 1.0f)
 										: tcu::Vec2(1.0f, 0.0f);
 
@@ -1110,7 +1110,7 @@ static bool verifyMultisampleLineGroupInterpolationInternal (const tcu::Surface&
 		};
 
 		const tcu::Vec2 lineDir			= tcu::normalize(lineScreenSpace[1] - lineScreenSpace[0]);
-		const tcu::Vec2 lineNormalDir	= strictMode ? tcu::Vec2(lineDir.y(), -lineDir.x())
+		const tcu::Vec2 lineNormalDir	= (strictMode || scene.isRectangular) ? tcu::Vec2(lineDir.y(), -lineDir.x())
 										: isLineXMajor(lineScreenSpace[0], lineScreenSpace[1]) ? tcu::Vec2(0.0f, 1.0f)
 										: tcu::Vec2(1.0f, 0.0f);
 

--- a/framework/common/tcuRasterizationVerifier.hpp
+++ b/framework/common/tcuRasterizationVerifier.hpp
@@ -76,6 +76,7 @@ struct LineSceneSpec
 	LineSceneSpec()
 		: isStrip(false)
 		, isSmooth(false)
+		, isRectangular(false)
 		, stippleEnable(false)
 		, verificationMode(VERIFICATIONMODE_STRICT)
 	{}
@@ -90,6 +91,7 @@ struct LineSceneSpec
 	float					lineWidth;
 	bool					isStrip;
 	bool					isSmooth;
+	bool					isRectangular;
 	bool					stippleEnable;
 	deUint32				stippleFactor;
 	deUint16				stipplePattern;


### PR DESCRIPTION
When we're testing against rectangular lines, we need to generate the
rectangular line geometry as well, otherwise we'll test against
parallelogram lines instead.

Fixes #274