### PR TITLE
Require unsized half-float textures to be renderable

### DIFF
--- a/modules/gles2/functional/es2fFboCompletenessTests.cpp
+++ b/modules/gles2/functional/es2fFboCompletenessTests.cpp
@@ -96,6 +96,12 @@ static const FormatKey s_oesTextureHalfFloatFormats[] =
 	GLS_UNSIZED_FORMATKEY(GL_RGB,	GL_HALF_FLOAT_OES),
 };
 
+// GL_EXT_color_buffer_half_float
+static const FormatKey s_extColorBufferHalfFloatUnsized[] =
+{
+	GLS_UNSIZED_FORMATKEY(GL_RGBA,	GL_HALF_FLOAT_OES),
+};
+
 // GL_EXT_sRGB_write_control
 static const FormatKey s_extSrgbWriteControlFormats[] =
 {
@@ -167,6 +173,13 @@ static const FormatExtEntry s_es2ExtFormats[] =
 		"GL_OES_texture_half_float",
 		(deUint32)TEXTURE_VALID,
 		GLS_ARRAY_RANGE(s_oesTextureHalfFloatFormats)
+	},
+        // However GL_EXT_color_buffer_half_float does say explicitly
+        // that the RGBA variant should be renderable.
+	{
+		"GL_OES_texture_half_float GL_EXT_color_buffer_half_float",
+		(deUint32)(REQUIRED_RENDERABLE | COLOR_RENDERABLE),
+		GLS_ARRAY_RANGE(s_extColorBufferHalfFloatUnsized)
 	},
 
 	// GL_EXT_sRGB_write_control makes SRGB8_ALPHA8 color-renderable


### PR DESCRIPTION
The GL_EXT_color_buffer_half_float spec is pretty clear on requiring
this:

    If OES_texture_half_float is supported, textures created with:

	<internalformat> = RGBA
	<format> = RGBA
	<type> = HALF_FLOAT_OES

    are renderable.

Affects:
  dEQP-GLES2.functional.fbo.completeness.renderable.texture.color0.rgba_half_float_oes