### PR TITLE
Ensure the pesence of GL_ARB_buffer_storage for buffer alignment tests

### DIFF
--- a/external/openglcts/modules/gl/gl4cMapBufferAlignmentTests.cpp
+++ b/external/openglcts/modules/gl/gl4cMapBufferAlignmentTests.cpp
@@ -28,6 +28,7 @@
 
 #include "gl4cMapBufferAlignmentTests.hpp"
 
+#include "gluContextInfo.hpp"
 #include "gluDefs.hpp"
 #include "glwEnums.hpp"
 #include "glwFunctions.hpp"
@@ -104,6 +105,7 @@ public:
 		/* Nothing to be done */
 	}
 
+	void init();
 	/** Execute test
 	 *
 	 * @return tcu::TestNode::STOP
@@ -149,6 +151,14 @@ struct BufferEnums
 	GLenum m_target;
 	GLenum m_max_size;
 };
+
+void Functional::init(void)
+{
+	if (!m_context.getContextInfo().isExtensionSupported("GL_ARB_buffer_storage"))
+	{
+		TCU_THROW(NotSupportedError, "GL_ARB_buffer_storage not supported");
+	}
+}
 
 /** Execute test
  *


### PR DESCRIPTION
This make sure that we won't call gl.bufferStorage if this isn't possible.

Signed-off-by: Corentin Noël <corentin.noel@collabora.com>