### PR TITLE
use library sonames for linking

### DIFF
--- a/framework/egl/egluGLContextFactory.cpp
+++ b/framework/egl/egluGLContextFactory.cpp
@@ -63,7 +63,7 @@ using std::vector;
 #	if (DE_OS == DE_OS_WIN32)
 #		define DEQP_GLES2_LIBRARY_PATH "libGLESv2.dll"
 #	else
-#		define DEQP_GLES2_LIBRARY_PATH "libGLESv2.so"
+#		define DEQP_GLES2_LIBRARY_PATH "libGLESv2.so.2"
 #	endif
 #endif
 
@@ -75,7 +75,7 @@ using std::vector;
 #	if (DE_OS == DE_OS_WIN32)
 #		define DEQP_OPENGL_LIBRARY_PATH "opengl32.dll"
 #	else
-#		define DEQP_OPENGL_LIBRARY_PATH "libGL.so"
+#		define DEQP_OPENGL_LIBRARY_PATH "libGL.so.1"
 #	endif
 #endif
 

--- a/framework/egl/wrapper/eglwLibrary.cpp
+++ b/framework/egl/wrapper/eglwLibrary.cpp
@@ -148,7 +148,7 @@ DefaultLibrary::~DefaultLibrary (void)
 const char* DefaultLibrary::getLibraryFileName (void)
 {
 #if (DE_OS == DE_OS_ANDROID) || (DE_OS == DE_OS_UNIX)
-	return "libEGL.so";
+	return "libEGL.so.1";
 #elif (DE_OS == DE_OS_WIN32)
 	return "libEGL.dll";
 #else

--- a/framework/platform/android/tcuAndroidPlatform.cpp
+++ b/framework/platform/android/tcuAndroidPlatform.cpp
@@ -57,7 +57,7 @@ static const eglu::NativeWindow::Capability		WINDOW_CAPABILITIES		= (eglu::Nativ
 class NativeDisplay : public eglu::NativeDisplay
 {
 public:
-									NativeDisplay			(void) : eglu::NativeDisplay(DISPLAY_CAPABILITIES), m_library("libEGL.so") {}
+									NativeDisplay			(void) : eglu::NativeDisplay(DISPLAY_CAPABILITIES), m_library("libEGL.so.1") {}
 	virtual							~NativeDisplay			(void) {}
 
 	virtual EGLNativeDisplayType	getLegacyNative			(void)			{ return EGL_DEFAULT_DISPLAY;	}

--- a/framework/platform/lnx/X11/tcuLnxX11EglDisplayFactory.cpp
+++ b/framework/platform/lnx/X11/tcuLnxX11EglDisplayFactory.cpp
@@ -75,7 +75,7 @@ class Library : public eglw::DefaultLibrary
 {
 public:
 	Library (void)
-		: eglw::DefaultLibrary("libEGL.so")
+		: eglw::DefaultLibrary("libEGL.so.1")
 	{
 	}
 

--- a/framework/platform/lnx/wayland/tcuLnxWaylandEglDisplayFactory.cpp
+++ b/framework/platform/lnx/wayland/tcuLnxWaylandEglDisplayFactory.cpp
@@ -66,7 +66,7 @@ public:
 													 EGL_PLATFORM_WAYLAND_KHR,
 													 "EGL_KHR_platform_wayland")
 									, m_display		(waylandDisplay)
-									, m_library		("libEGL.so") {}
+									, m_library		("libEGL.so.1") {}
 
 	~Display(void) {}
 	wayland::Display&			getWaylandDisplay	(void)	{ return *m_display; }

--- a/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
+++ b/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
@@ -69,7 +69,7 @@ using std::vector;
 
 // Default library names
 #if !defined(DEQP_GLES2_LIBRARY_PATH)
-#	define DEQP_GLES2_LIBRARY_PATH "libGLESv2.so"
+#	define DEQP_GLES2_LIBRARY_PATH "libGLESv2.so.2"
 #endif
 
 #if !defined(DEQP_GLES3_LIBRARY_PATH)
@@ -77,7 +77,7 @@ using std::vector;
 #endif
 
 #if !defined(DEQP_OPENGL_LIBRARY_PATH)
-#	define DEQP_OPENGL_LIBRARY_PATH "libGL.so"
+#	define DEQP_OPENGL_LIBRARY_PATH "libGL.so.1"
 #endif
 
 #if !defined(DEQP_VULKAN_LIBRARY_PATH)
@@ -248,7 +248,7 @@ glu::RenderContext* ContextFactory::createContext(const glu::RenderConfig& confi
 }
 
 EglRenderContext::EglRenderContext(const glu::RenderConfig& config, const tcu::CommandLine& cmdLine)
-	: m_egl("libEGL.so")
+	: m_egl("libEGL.so.1")
 	, m_contextType(config.type)
 	, m_eglDisplay(EGL_NO_DISPLAY)
 	, m_eglContext(EGL_NO_CONTEXT)


### PR DESCRIPTION
The recommended "best practices" for applications is to link to library
sonames (e.g. libGL.so.1) instead of library names (e.g. libGL.so). This
ensures that applications don't try to use libraries if an incompatible ABI
change occurs.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>