### PR TITLE
fetch_sources.py allows fetches by ssh protocol in the true sense

### DIFF
--- a/external/fetch_sources.py
+++ b/external/fetch_sources.py
@@ -250,6 +250,9 @@ class GitRepo (Source):
 			protocol = 'https'
 		return protocol
 
+	def https2sshUrl(self, httpsUrl):
+		return httpsUrl.replace("https://github.com/", "git@github.com:")
+
 	def selectUrl(self, cmdProtocol = None):
 		try:
 			if cmdProtocol == None:
@@ -265,7 +268,7 @@ class GitRepo (Source):
 				url = self.sshUrl
 			else:
 				assert self.httpsUrl != None
-				url = self.httpsUrl
+				url = self.https2sshUrl(self.httpsUrl)
 		else:
 			assert protocol == 'https'
 			url = self.httpsUrl


### PR DESCRIPTION
In case of poor cyber condition, git fetches based on ssh protocol
instead of https may be a better choice. The only thing that needs
is an appropriate url.

Signed-off-by: luc <luc@sietium.com>