### PR TITLE
remove a wrong qualityWarning for fbo completeness test

### DIFF
--- a/modules/glshared/glsFboCompletenessTests.cpp
+++ b/modules/glshared/glsFboCompletenessTests.cpp
@@ -669,6 +669,17 @@ IterateResult TestBase::iterate (void)
 				// An incomplete status is allowed, but not _this_ incomplete status.
 				fail("Framebuffer checked as incomplete, but with wrong status");
 		}
+		else if (fboStatus == GL_FRAMEBUFFER_UNSUPPORTED)
+		{
+		    /*The spec requires
+		         "when both depth and stencil attachments are present,implementations are only required
+			  to support framebuffer objects where both attachments refer to the same image."
+
+			  Thus,it is accepatable for an implementation returning GL_FRAMEBUFFER_UNSUPPORTED.
+			  And the test cannot be marked as failed.
+                    */
+		    pass();
+		}
 		else if (fboStatus != GL_FRAMEBUFFER_COMPLETE && reference.isFBOStatusValid(GL_FRAMEBUFFER_COMPLETE))
 			qualityWarning("Framebuffer object could have checked as complete but did not.");
 		else


### PR DESCRIPTION
For issue#296(https://github.com/KhronosGroup/VK-GL-CTS/issues/296). Change a wrong QualityWarning to pass.