### PR TITLE
allow non-preferred line interpolation for gles

### DIFF
--- a/framework/common/tcuRasterizationVerifier.cpp
+++ b/framework/common/tcuRasterizationVerifier.cpp
@@ -1997,6 +1997,11 @@ bool verifySinglesampleNarrowLineGroupInterpolation (const tcu::Surface& surface
 	return verifyLineGroupPixelIndependentInterpolation(surface, scene, args, log, LINEINTERPOLATION_STRICTLY_CORRECT);
 }
 
+bool verifyLineGroupInterpolationWithNonProjectedWeights (const tcu::Surface& surface, const LineSceneSpec& scene, const RasterizationArguments& args, tcu::TestLog& log)
+{
+	return verifyLineGroupPixelIndependentInterpolation(surface, scene, args, log, LINEINTERPOLATION_STRICTLY_CORRECT);
+}
+
 bool verifyLineGroupInterpolationWithProjectedWeights (const tcu::Surface& surface, const LineSceneSpec& scene, const RasterizationArguments& args, tcu::TestLog& log)
 {
 	return verifyLineGroupPixelIndependentInterpolation(surface, scene, args, log, LINEINTERPOLATION_PROJECTED);
@@ -3003,6 +3008,10 @@ LineInterpolationMethod verifyLineGroupInterpolation (const tcu::Surface& surfac
 		else
 		{
 			if (verifySinglesampleWideLineGroupInterpolation(surface, scene, args, log))
+				return LINEINTERPOLATION_STRICTLY_CORRECT;
+
+			if (scene.allowNonProjectedInterpolation &&
+			    verifyLineGroupInterpolationWithNonProjectedWeights(surface, scene, args, log))
 				return LINEINTERPOLATION_STRICTLY_CORRECT;
 		}
 

--- a/framework/common/tcuRasterizationVerifier.hpp
+++ b/framework/common/tcuRasterizationVerifier.hpp
@@ -92,6 +92,7 @@ struct LineSceneSpec
 	bool					isStrip;
 	bool					isSmooth;
 	bool					isRectangular;
+	bool					allowNonProjectedInterpolation;
 	bool					stippleEnable;
 	deUint32				stippleFactor;
 	deUint16				stipplePattern;

--- a/modules/gles2/functional/es2fRasterizationTests.cpp
+++ b/modules/gles2/functional/es2fRasterizationTests.cpp
@@ -372,6 +372,7 @@ BaseLineCase::IterateResult BaseLineCase::iterate (void)
 		scene.lineWidth = m_lineWidth;
 		scene.stippleFactor = 1;
 		scene.stipplePattern = 0xFFFF;
+		scene.allowNonProjectedInterpolation = true;
 
 		compareOk = verifyLineGroupRasterization(resultImage, scene, args, m_testCtx.getLog());
 
@@ -1799,6 +1800,7 @@ LineInterpolationTest::IterateResult LineInterpolationTest::iterate (void)
 		scene.lineWidth = m_lineWidth;
 		scene.stippleFactor = 1;
 		scene.stipplePattern = 0xFFFF;
+		scene.allowNonProjectedInterpolation = true;
 
 
 		iterationResult = verifyLineGroupInterpolation(resultImage, scene, args, m_testCtx.getLog());

--- a/modules/gles3/functional/es3fRasterizationTests.cpp
+++ b/modules/gles3/functional/es3fRasterizationTests.cpp
@@ -603,6 +603,7 @@ BaseLineCase::IterateResult BaseLineCase::iterate (void)
 			scene.lineWidth = lineWidth;
 			scene.stippleFactor = 1;
 			scene.stipplePattern = 0xFFFF;
+			scene.allowNonProjectedInterpolation = true;
 
 			compareOk = verifyLineGroupRasterization(resultImage, scene, args, m_testCtx.getLog());
 
@@ -2021,6 +2022,7 @@ LineInterpolationTest::IterateResult LineInterpolationTest::iterate (void)
 			scene.lineWidth = getLineWidth();
 			scene.stippleFactor = 1;
 			scene.stipplePattern = 0xFFFF;
+			scene.allowNonProjectedInterpolation = true;
 
 
 			iterationResult = verifyLineGroupInterpolation(resultImage, scene, args, m_testCtx.getLog());


### PR DESCRIPTION
The OpenGL ES 3.2 spec, section 13.6.2.1 ("Wide Lines") says the
following:

---8<---
The preferred method of attribute interpolation for a wide line is to
generate the same attribute values for all fragments in the row or
column described above, as if the adjusted line were used for
interpolation and those values replicated to the other fragments,
except for gl_FragCoord which is interpolated as usual. An
implementation may instead interpolate each fragment according to the
formula in "Basic Line Segment Rasterization", using the original
line segment endpoints.
---8<---

However, the code that verified the interpolation only checked against
the preferred interpolation.

Luckily, we have code that does the right checking. By marking the ES2
and ES3 line-rasterization tests with a bit to allow this, we can hook
this up as appropriate.

Components: OpenGL ES, Framework

Public Issue: 273

Affected Tests:
dEQP-GLES2.functional.rasterization.interpolation.*_wide
dEQP-GLES3.functional.rasterization.interpolation.line_wide
dEQP-GLES3.functional.rasterization.fbo.rbo_singlesample.interpolation.lines_wide
dEQP-GLES3.functional.rasterization.fbo.texture_2d.interpolation.lines_wide