### PR TITLE
Flush stdout after printing test name and result on Windows

### DIFF
--- a/framework/common/tcuTestSessionExecutor.cpp
+++ b/framework/common/tcuTestSessionExecutor.cpp
@@ -197,6 +197,10 @@ bool TestSessionExecutor::enterTestCase (TestCase* testCase, const std::string& 
 
 	print("\nTest case '%s'..\n", casePath.c_str());
 
+#if (DE_OS == DE_OS_WIN32)
+	fflush(stdout);
+#endif
+
 	m_testCtx.setTestResult(QP_TEST_RESULT_LAST, "");
 	m_testCtx.setTerminateAfter(false);
 	log.startCase(casePath.c_str(), caseType);
@@ -267,6 +271,10 @@ void TestSessionExecutor::leaveTestCase (TestCase* testCase)
 
 		// Update statistics.
 		print("  %s (%s)\n", qpGetTestResultName(testResult), testResultDesc);
+
+#if (DE_OS == DE_OS_WIN32)
+		fflush(stdout);
+#endif
 
 		m_status.numExecuted += 1;
 		switch (testResult)


### PR DESCRIPTION
On other platforms, the standard output mode is changed to line
buffered, but that isn't possible on Windows. To allow other tools
(such as deqp-runner) to properly parse the output even if a
crash occurs, we need to flush after printing the test case name
and result.

Fixes: #311 