### PR TITLE
Fix ShaderBallotFunctionRead test

### DIFF
--- a/external/openglcts/modules/gl/gl4cShaderBallotTests.cpp
+++ b/external/openglcts/modules/gl/gl4cShaderBallotTests.cpp
@@ -432,18 +432,18 @@ bool ShaderBallotBaseTestCase::validateScreenPixelsSameColor(deqp::Context& cont
 	const tcu::RenderTarget renderTarget = context.getRenderContext().getRenderTarget();
 	tcu::IVec2				size(renderTarget.getWidth(), renderTarget.getHeight());
 
-	glw::GLfloat* centerPixel = new glw::GLfloat[4];
-	centerPixel[0]			  = -1.0f;
-	centerPixel[1]			  = -1.0f;
-	centerPixel[2]			  = -1.0f;
-	centerPixel[3]			  = -1.0f;
+	glw::GLfloat* topLeftPixel = new glw::GLfloat[4];
+	topLeftPixel[0]			  = -1.0f;
+	topLeftPixel[1]			  = -1.0f;
+	topLeftPixel[2]			  = -1.0f;
+	topLeftPixel[3]			  = -1.0f;
 
 	// read pixel
-	gl.readPixels(size.x() / 2, size.y() / 2, 1, 1, GL_RGBA, GL_FLOAT, centerPixel);
+	gl.readPixels(0, 0, 1, 1, GL_RGBA, GL_FLOAT, topLeftPixel);
 
-	tcu::Vec4 desiredColor(centerPixel[0], centerPixel[1], centerPixel[2], centerPixel[3]);
+	tcu::Vec4 desiredColor(topLeftPixel[0], topLeftPixel[1], topLeftPixel[2], topLeftPixel[3]);
 
-	delete[] centerPixel;
+	delete[] topLeftPixel;
 
 	// validation
 	return ShaderBallotBaseTestCase::validateScreenPixels(context, desiredColor, ignoredColor);
@@ -731,7 +731,7 @@ tcu::TestNode::IterateResult ShaderBallotFunctionReadTestCase::iterate()
 	const tcu::RenderTarget renderTarget = m_context.getRenderContext().getRenderTarget();
 
 	gl.clearColor(1.0f, 0.0f, 0.0f, 1.0f);
-	gl.viewport(renderTarget.getWidth() / 2 - 1, renderTarget.getHeight() / 2 - 1, 2, 2);
+	gl.viewport(0, 0, 2, 2);
 
 	for (ShaderPipelineIter pipelineIter = m_shaderPipelines.begin(); pipelineIter != m_shaderPipelines.end();
 		 ++pipelineIter)


### PR DESCRIPTION
The current version of the test draws at 2x2 quad, expecting the value of the
4 pixels to be the same because readFirstInvocationARB is used.

The problem is that depending on the resolution used: if the 4 fragments are
processed in more than one sub-group, then the test will fail.
For instance, on AMD hw the test would pass using the default resolution, but
fail for 256x256.

Fix this by drawing in the top-left corner instead of the middle of the screen.

See https://github.com/KhronosGroup/VK-GL-CTS/issues/251