### PR TITLE
Only pass VkImageViewMinLodCreateInfoEXT when minLod is != 0.0f

### DIFF
--- a/external/vulkancts/modules/vulkan/texture/vktTextureTestUtil.cpp
+++ b/external/vulkancts/modules/vulkan/texture/vktTextureTestUtil.cpp
@@ -475,7 +475,7 @@ void TextureBinding::updateTextureViewMipLevels (deUint32 baseLevel, deUint32 ma
 	{
 		vk::VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,						// VkStructureType			sType;
 #ifndef CTS_USES_VULKANSC
-		imageViewMinLod >= 0.0f ? &imageViewMinLodCreateInfo : DE_NULL,		// const void*				pNext;
+		imageViewMinLod > 0.0f ? &imageViewMinLodCreateInfo : DE_NULL,		// const void*				pNext;
 #else
 		DE_NULL,															// const void*				pNext;
 #endif // CTS_USES_VULKANSC


### PR DESCRIPTION
We avoid to passing VkImageViewMinLodCreateInfoEXT when creating
the image view when the tests are actually not testing this.

Therefore, the drivers that don't support this extension won't
see errors when processing VkImageViewCreateInfo.

Components: Vulkan
VK-GL-CTS issue: 3094

Affected tests:

    dEQP-VK.texture.mipmap.*

Signed-off-by: Samuel Iglesias Gonsálvez <siglesias@igalia.com>
Change-Id: I09110ef2e6ebfb6f55c084eda85359ebf5cfa742