### PR TITLE
Remove usages of std::iterator

### DIFF
--- a/framework/common/tcuRandomValueIterator.hpp
+++ b/framework/common/tcuRandomValueIterator.hpp
@@ -55,9 +55,15 @@ template <> inline deInt32	getRandomValue<deInt32>		(de::Random& rnd) { return (
 template <> inline deInt64	getRandomValue<deInt64>		(de::Random& rnd) { return (deInt64)rnd.getUint64();	}
 
 template <typename T>
-class RandomValueIterator : public std::iterator<std::forward_iterator_tag, T>
+class RandomValueIterator
 {
 public:
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = T;
+	using difference_type = std::ptrdiff_t;
+	using pointer = T*;
+	using reference = T&;
+
 	static RandomValueIterator	begin					(deUint32 seed, int numValues)	{ return RandomValueIterator<T>(seed, numValues);	}
 	static RandomValueIterator	end						(void)							{ return RandomValueIterator<T>(0, 0);				}
 

--- a/framework/opengl/gluVarTypeUtil.hpp
+++ b/framework/opengl/gluVarTypeUtil.hpp
@@ -157,9 +157,15 @@ private:
 
 // \note VarType must be live during iterator usage.
 template <class IsExpanded>
-class SubTypeIterator : public std::iterator<std::forward_iterator_tag, VarType>
+class SubTypeIterator
 {
 public:
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = VarType;
+	using difference_type = std::ptrdiff_t;
+	using pointer = VarType*;
+	using reference = VarType&;
+
 	static SubTypeIterator<IsExpanded>	begin				(const VarType* type) { return SubTypeIterator(type);						}
 	static SubTypeIterator<IsExpanded>	end					(const VarType* type) { DE_UNREF(type); return SubTypeIterator(DE_NULL);	}
 

--- a/framework/randomshaders/rsgVariableManager.hpp
+++ b/framework/randomshaders/rsgVariableManager.hpp
@@ -116,9 +116,15 @@ public:
 
 // \todo [2011-05-26 pyry] Clean up this a bit, separate const variant.
 template <typename Item, typename Iterator, class Filter>
-class FilteredIterator : public std::iterator<std::input_iterator_tag, Item>
+class FilteredIterator
 {
 public:
+	using iterator_category = std::input_iterator_tag;
+	using value_type = Item;
+	using difference_type = std::ptrdiff_t;
+	using pointer = Item*;
+	using reference = Item&;
+
 	FilteredIterator (Iterator iter, Iterator end, Filter filter)
 		: m_iter	(iter)
 		, m_end		(end)


### PR DESCRIPTION
std::iterator is deprecated in C++17, and it's presence is blocking Chromium from updating libc++ (https://crbug.com/1273285).