### PR TITLE
[Fix] fix C++ tuple constexpr initial list on old compiler

### DIFF
--- a/external/vulkancts/modules/vulkan/ray_tracing/vktRayTracingTraceRaysTests.cpp
+++ b/external/vulkancts/modules/vulkan/ray_tracing/vktRayTracingTraceRaysTests.cpp
@@ -179,8 +179,11 @@ std::tuple<bool, VkQueue, deUint32> getQueueFamilyIndexAtExact (const DeviceInte
 		found = true;
 		vkd.getDeviceQueue(device, queueFamilyIndex, queueIndex, &queue);
 	}
-
+#ifdef __cpp_lib_constexpr_tuple
 	return { found, queue, queueFamilyIndex };
+#else
+    return std::tuple<bool, VkQueue, deUint32>(found, queue, queueFamilyIndex);
+#endif
 }
 
 typedef std::vector<de::SharedPtr<BottomLevelAccelerationStructure>>	BlasVec;


### PR DESCRIPTION
Compilation pass on both aarch64/debian(g++5) machine and X86_64/ubuntu (g++ 11.2.0)