### PR TITLE
Fix portability of python3

### DIFF
--- a/scripts/log/log_parser.py
+++ b/scripts/log/log_parser.py
@@ -108,9 +108,9 @@ class BatchResultParser:
 			del self.testCaseResults[:]
 			self.curResultText = None
 
-			isNextResult = self.parseLine(file.next())
+			isNextResult = self.parseLine(next(file))
 			while not isNextResult:
-				isNextResult = self.parseLine(file.next())
+				isNextResult = self.parseLine(next(file))
 
 			# Return the next TestCaseResult
 			return self.testCaseResults.pop()


### PR DESCRIPTION
Using the script to convert qpa to xml under python3.10, the following issues met:

```bash
$ python --version
Python 3.10.2
$ python log/log_to_xml.py TestResults.qpa  TestResult.xml
Traceback (most recent call last):
  File "D:\OpenSource\VK-GL-CTS-vulkan-cts\scripts\log\log_to_xml.py", line 200, in <module>
    logToXml(sys.argv[1], sys.argv[2])
  File "D:\OpenSource\VK-GL-CTS-vulkan-cts\scripts\log\log_to_xml.py", line 168, in logToXml
    result = parser.getNextTestCaseResult(logFile)
  File "D:\OpenSource\VK-GL-CTS-vulkan-cts\scripts\log\log_parser.py", line 111, in getNextTestCaseResult
    isNextResult = self.parseLine(file.next())
AttributeError: '_io.BufferedReader' object has no attribute 'next'
```
The `next` method seems to be removed in python3 and replace it with a built-in function here.
https://github.com/KhronosGroup/VK-GL-CTS/blob/692df061716dd713e74483dc3255bfd4b1779843/scripts/log/log_parser.py#L111