### PR TITLE
Fix script arguments in vulkancts CMakeLists

### DIFF
--- a/external/vulkancts/framework/vulkan/CMakeLists.txt
+++ b/external/vulkancts/framework/vulkan/CMakeLists.txt
@@ -70,9 +70,9 @@ if (DEQP_VULKAN_INL_GEN_OUTPUTS_DIR MATCHES ^${PROJECT_BINARY_DIR})
 		COMMAND cmake -E remove ${DEQP_VULKAN_INL_GEN_OUTPUTS}
 
 		# Generate all inl files.
-		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_ext_deps.py ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
-		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_framework.py ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
-		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_framework_c.py ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
+		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_ext_deps.py -o ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
+		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_framework.py -o ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
+		COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/external/vulkancts/scripts/gen_framework_c.py -o ${DEQP_VULKAN_INL_GEN_OUTPUTS_DIR}
 
 		# Check all outputs exist, as CMake does not do this.
 		COMMAND cmake -E md5sum ${DEQP_VULKAN_INL_GEN_OUTPUTS}


### PR DESCRIPTION
The missing "-o" flag was causing build failures on Linux with python3.

Fixes: https://github.com/KhronosGroup/VK-GL-CTS/issues/339