### PR TITLE
Support GL 4.5 in the 'negative' tests

### DIFF
--- a/modules/gles3/functional/es3fNegativeBufferApiTests.cpp
+++ b/modules/gles3/functional/es3fNegativeBufferApiTests.cpp
@@ -233,6 +233,7 @@ void NegativeBufferApiTests::init (void)
 			std::vector<float>		floatData(4);
 			deUint32				fbo;
 			deUint32				texture;
+			bool					isES = glu::isContextTypeES(m_context.getRenderContext().getType());
 
 			glGenTextures			(1, &texture);
 			glBindTexture			(GL_TEXTURE_2D, texture);
@@ -249,7 +250,7 @@ void NegativeBufferApiTests::init (void)
 			glCheckFramebufferStatus(GL_FRAMEBUFFER);
 			expectError				(GL_NO_ERROR);
 			glReadPixels			(0, 0, 1, 1, GL_RGBA, GL_FLOAT, &floatData[0]);
-			expectError				(GL_INVALID_OPERATION);
+			expectError				(isES ? GL_INVALID_OPERATION : GL_NO_ERROR);
 
 			glTexImage2D			(GL_TEXTURE_2D, 0, GL_RGBA32I, 32, 32, 0, GL_RGBA_INTEGER, GL_INT, NULL);
 			glFramebufferTexture2D	(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
@@ -645,6 +646,7 @@ void NegativeBufferApiTests::init (void)
 			values[2]				= GL_COLOR_ATTACHMENT0;
 			values[3]				= GL_DEPTH_ATTACHMENT;
 			std::vector<GLfloat>	data(32*32);
+			bool					isES = glu::isContextTypeES(m_context.getRenderContext().getType());
 
 			glGenTextures			(1, &texture);
 			glBindTexture			(GL_TEXTURE_2D, texture);
@@ -675,7 +677,7 @@ void NegativeBufferApiTests::init (void)
 			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the GL is bound to a framebuffer object and the ith buffer listed in bufs is anything other than GL_NONE or GL_COLOR_ATTACHMENTSi.");
 			glBindFramebuffer		(GL_FRAMEBUFFER, fbo);
 			glDrawBuffers			(1, &values[1]);
-			expectError				(GL_INVALID_OPERATION);
+			expectError				(isES ? GL_INVALID_OPERATION : GL_INVALID_ENUM);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_INVALID_VALUE is generated if n is less than 0 or greater than GL_MAX_DRAW_BUFFERS.");
@@ -809,6 +811,7 @@ void NegativeBufferApiTests::init (void)
 			deUint32				fbo;
 			deUint32				texture;
 			int						maxColorAttachments;
+			bool					isES = glu::isContextTypeES(m_context.getRenderContext().getType());
 
 			glGetIntegerv			(GL_MAX_COLOR_ATTACHMENTS, &maxColorAttachments);
 			glGenTextures			(1, &texture);
@@ -830,7 +833,7 @@ void NegativeBufferApiTests::init (void)
 			glReadBuffer			(GL_COLOR_ATTACHMENT0 - 1);
 			expectError				(GL_INVALID_ENUM);
 			glReadBuffer			(GL_FRONT);
-			expectError				(GL_INVALID_ENUM);
+			expectError				(isES ? GL_INVALID_ENUM : GL_INVALID_OPERATION);
 
 			// \ note Spec isn't actually clear here, but it is safe to assume that
 			//		  GL_DEPTH_ATTACHMENT can't be interpreted as GL_COLOR_ATTACHMENTm
@@ -1043,6 +1046,8 @@ void NegativeBufferApiTests::init (void)
 	ES3F_ADD_API_CASE(renderbuffer_storage, "Invalid glRenderbufferStorage() usage",
 		{
 			deUint32				rbo;
+			bool					isES = glu::isContextTypeES(m_context.getRenderContext().getType());
+
 			glGenRenderbuffers		(1, &rbo);
 			glBindRenderbuffer		(GL_RENDERBUFFER, rbo);
 
@@ -1060,13 +1065,13 @@ void NegativeBufferApiTests::init (void)
 			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_color_buffer_half_float")) // GL_EXT_color_buffer_half_float disables error
 			{
 				glRenderbufferStorage	(GL_RENDERBUFFER, GL_RGB16F, 1, 1);
-				expectError				(GL_INVALID_ENUM);
+				expectError				(isES ? GL_INVALID_ENUM : GL_NO_ERROR);
 			}
 
 			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_render_snorm")) // GL_EXT_render_snorm disables error
 			{
 				glRenderbufferStorage	(GL_RENDERBUFFER, GL_RGBA8_SNORM, 1, 1);
-				expectError				(GL_INVALID_ENUM);
+				expectError				(isES ? GL_INVALID_ENUM : GL_NO_ERROR);
 			}
 
 			m_log << TestLog::EndSection;
@@ -1207,25 +1212,27 @@ void NegativeBufferApiTests::init (void)
 
 			if (!m_context.getContextInfo().isExtensionSupported("GL_NV_framebuffer_multisample"))
 			{
+				bool isES = glu::isContextTypeES(m_context.getRenderContext().getType());
+
 				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the value of GL_SAMPLE_BUFFERS for the draw buffer is greater than zero.");
 				glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_RGBA8, 32, 32);
 				glFramebufferRenderbuffer		(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rbo[1]);
 				glBlitFramebuffer				(0, 0, 16, 16, 0, 0, 16, 16, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-				expectError						(GL_INVALID_OPERATION);
+				expectError						(isES ? GL_INVALID_OPERATION : GL_NO_ERROR);
 				m_log << TestLog::EndSection;
 
 				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater than zero and the formats of draw and read buffers are not identical.");
 				glRenderbufferStorage			(GL_RENDERBUFFER, GL_RGBA4, 32, 32);
 				glFramebufferRenderbuffer		(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rbo[1]);
 				glBlitFramebuffer				(0, 0, 16, 16, 0, 0, 16, 16, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-				expectError						(GL_INVALID_OPERATION);
+				expectError						(isES ? GL_INVALID_OPERATION : GL_NO_ERROR);
 				m_log << TestLog::EndSection;
 
 				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater than zero and the source and destination rectangles are not defined with the same (X0, Y0) and (X1, Y1) bounds.");
 				glRenderbufferStorage			(GL_RENDERBUFFER, GL_RGBA8, 32, 32);
 				glFramebufferRenderbuffer		(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rbo[1]);
 				glBlitFramebuffer				(0, 0, 16, 16, 2, 2, 18, 18, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-				expectError						(GL_INVALID_OPERATION);
+				expectError						(isES ? GL_INVALID_OPERATION : GL_NO_ERROR);
 				m_log << TestLog::EndSection;
 			}
 
@@ -1378,6 +1385,7 @@ void NegativeBufferApiTests::init (void)
 		{
 			deUint32							rbo;
 			int									maxSamplesSupportedRGBA4 = -1;
+			bool								isES = glu::isContextTypeES(m_context.getRenderContext().getType());
 
 			glGetInternalformativ				(GL_RENDERBUFFER, GL_RGBA4, GL_SAMPLES, 1, &maxSamplesSupportedRGBA4);
 			glGenRenderbuffers					(1, &rbo);
@@ -1402,13 +1410,13 @@ void NegativeBufferApiTests::init (void)
 			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_color_buffer_half_float")) // GL_EXT_color_buffer_half_float disables error
 			{
 				glRenderbufferStorageMultisample	(GL_RENDERBUFFER, 2, GL_RGB16F, 1, 1);
-				expectError							(GL_INVALID_ENUM);
+				expectError							(isES ? GL_INVALID_ENUM : GL_NO_ERROR);
 			}
 
 			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_render_snorm")) // GL_EXT_render_snorm disables error
 			{
 				glRenderbufferStorageMultisample	(GL_RENDERBUFFER, 2, GL_RGBA8_SNORM, 1, 1);
-				expectError							(GL_INVALID_ENUM);
+				expectError							(isES ? GL_INVALID_ENUM : GL_NO_ERROR);
 			}
 
 			m_log << TestLog::EndSection;

--- a/modules/gles3/functional/es3fNegativeShaderApiTests.cpp
+++ b/modules/gles3/functional/es3fNegativeShaderApiTests.cpp
@@ -218,10 +218,12 @@ void NegativeShaderApiTests::init (void)
 			expectError(GL_INVALID_OPERATION);
 			m_log << TestLog::EndSection;
 
-			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if a shader of the same type as shader is already attached to program.");
-			glAttachShader(program, shader2);
-			expectError(GL_INVALID_OPERATION);
-			m_log << TestLog::EndSection;
+			if (glu::isContextTypeES(m_context.getRenderContext().getType())){
+				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if a shader of the same type as shader is already attached to program.");
+				glAttachShader(program, shader2);
+				expectError(GL_INVALID_OPERATION);
+				m_log << TestLog::EndSection;
+			}
 
 			glDeleteProgram(program);
 			glDeleteShader(shader1);

--- a/modules/gles3/functional/es3fNegativeShaderApiTests.cpp
+++ b/modules/gles3/functional/es3fNegativeShaderApiTests.cpp
@@ -380,45 +380,48 @@ void NegativeShaderApiTests::init (void)
 
 			glDeleteShader(shader);
 		});
-	ES3F_ADD_API_CASE(get_program_binary, "Invalid glGetProgramBinary() usage",
-		{
-			glu::ShaderProgram				program			(m_context.getRenderContext(), glu::makeVtxFragSources(vertexShaderSource, fragmentShaderSource));
-			glu::ShaderProgram				programInvalid	(m_context.getRenderContext(), glu::makeVtxFragSources(vertexShaderSource, ""));
-			GLenum							binaryFormat	= -1;
-			GLsizei							binaryLength	= -1;
-			GLint							binaryPtr		= -1;
-			GLint							bufSize			= -1;
-			GLint							linkStatus		= -1;
-
-			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if bufSize is less than the size of GL_PROGRAM_BINARY_LENGTH for program.");
-			glGetProgramiv		(program.getProgram(), GL_PROGRAM_BINARY_LENGTH,	&bufSize);
-			expectError			(GL_NO_ERROR);
-			glGetProgramiv		(program.getProgram(), GL_LINK_STATUS,				&linkStatus);
-			m_log << TestLog::Message << "// GL_PROGRAM_BINARY_LENGTH = " << bufSize << TestLog::EndMessage;
-			m_log << TestLog::Message << "// GL_LINK_STATUS = " << linkStatus << TestLog::EndMessage;
-			expectError			(GL_NO_ERROR);
-
-			glGetProgramBinary	(program.getProgram(), 0, &binaryLength, &binaryFormat, &binaryPtr);
-			expectError			(GL_INVALID_OPERATION);
-			if (bufSize > 0)
+	if (glu::isContextTypeES(m_context.getRenderContext().getType()))
+	{
+		ES3F_ADD_API_CASE(get_program_binary, "Invalid glGetProgramBinary() usage",
 			{
-				glGetProgramBinary	(program.getProgram(), bufSize-1, &binaryLength, &binaryFormat, &binaryPtr);
+				glu::ShaderProgram				program			(m_context.getRenderContext(), glu::makeVtxFragSources(vertexShaderSource, fragmentShaderSource));
+				glu::ShaderProgram				programInvalid	(m_context.getRenderContext(), glu::makeVtxFragSources(vertexShaderSource, ""));
+				GLenum							binaryFormat	= -1;
+				GLsizei							binaryLength	= -1;
+				GLint							binaryPtr		= -1;
+				GLint							bufSize			= -1;
+				GLint							linkStatus		= -1;
+
+				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if bufSize is less than the size of GL_PROGRAM_BINARY_LENGTH for program.");
+				glGetProgramiv		(program.getProgram(), GL_PROGRAM_BINARY_LENGTH,	&bufSize);
+				expectError			(GL_NO_ERROR);
+				glGetProgramiv		(program.getProgram(), GL_LINK_STATUS,				&linkStatus);
+				m_log << TestLog::Message << "// GL_PROGRAM_BINARY_LENGTH = " << bufSize << TestLog::EndMessage;
+				m_log << TestLog::Message << "// GL_LINK_STATUS = " << linkStatus << TestLog::EndMessage;
+				expectError			(GL_NO_ERROR);
+
+				glGetProgramBinary	(program.getProgram(), 0, &binaryLength, &binaryFormat, &binaryPtr);
 				expectError			(GL_INVALID_OPERATION);
-			}
-			m_log << TestLog::EndSection;
+				if (bufSize > 0)
+				{
+					glGetProgramBinary	(program.getProgram(), bufSize-1, &binaryLength, &binaryFormat, &binaryPtr);
+					expectError			(GL_INVALID_OPERATION);
+				}
+				m_log << TestLog::EndSection;
 
-			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if GL_LINK_STATUS for the program object is false.");
-			glGetProgramiv		(programInvalid.getProgram(), GL_PROGRAM_BINARY_LENGTH,	&bufSize);
-			expectError			(GL_NO_ERROR);
-			glGetProgramiv		(programInvalid.getProgram(), GL_LINK_STATUS,			&linkStatus);
-			m_log << TestLog::Message << "// GL_PROGRAM_BINARY_LENGTH = " << bufSize << TestLog::EndMessage;
-			m_log << TestLog::Message << "// GL_LINK_STATUS = " << linkStatus << TestLog::EndMessage;
-			expectError			(GL_NO_ERROR);
+				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if GL_LINK_STATUS for the program object is false.");
+				glGetProgramiv		(programInvalid.getProgram(), GL_PROGRAM_BINARY_LENGTH,	&bufSize);
+				expectError			(GL_NO_ERROR);
+				glGetProgramiv		(programInvalid.getProgram(), GL_LINK_STATUS,			&linkStatus);
+				m_log << TestLog::Message << "// GL_PROGRAM_BINARY_LENGTH = " << bufSize << TestLog::EndMessage;
+				m_log << TestLog::Message << "// GL_LINK_STATUS = " << linkStatus << TestLog::EndMessage;
+				expectError			(GL_NO_ERROR);
 
-			glGetProgramBinary	(programInvalid.getProgram(), bufSize, &binaryLength, &binaryFormat, &binaryPtr);
-			expectError			(GL_INVALID_OPERATION);
-			m_log << TestLog::EndSection;
-		});
+				glGetProgramBinary	(programInvalid.getProgram(), bufSize, &binaryLength, &binaryFormat, &binaryPtr);
+				expectError			(GL_INVALID_OPERATION);
+				m_log << TestLog::EndSection;
+			});
+	}
 	ES3F_ADD_API_CASE(program_binary, "Invalid glProgramBinary() usage",
 		{
 			glu::ShaderProgram		srcProgram		(m_context.getRenderContext(), glu::makeVtxFragSources(vertexShaderSource, fragmentShaderSource));

--- a/modules/gles3/functional/es3fNegativeStateApiTests.cpp
+++ b/modules/gles3/functional/es3fNegativeStateApiTests.cpp
@@ -931,6 +931,7 @@ void NegativeStateApiTests::init (void)
 		});
 	ES3F_ADD_API_CASE(get_internalformativ, "Invalid glGetInternalformativ() usage",
 		{
+			const bool isES	= glu::isContextTypeES(m_context.getRenderContext().getType());
 			GLint params[16];
 
 			deMemset(&params[0], 0xcd, sizeof(params));
@@ -945,16 +946,19 @@ void NegativeStateApiTests::init (void)
 			expectError				(GL_INVALID_ENUM);
 			m_log << TestLog::EndSection;
 
-			m_log << TestLog::Section("", "GL_INVALID_ENUM is generated if internalformat is not color-, depth-, or stencil-renderable.");
-			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_render_snorm"))
+			if (isES)
 			{
-				glGetInternalformativ	(GL_RENDERBUFFER, GL_RG8_SNORM, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
-				expectError				(GL_INVALID_ENUM);
-			}
+				m_log << TestLog::Section("", "GL_INVALID_ENUM is generated if internalformat is not color-, depth-, or stencil-renderable.");
+				if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_render_snorm"))
+				{
+					glGetInternalformativ	(GL_RENDERBUFFER, GL_RG8_SNORM, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
+					expectError				(GL_INVALID_ENUM);
+				}
 
-			glGetInternalformativ	(GL_RENDERBUFFER, GL_COMPRESSED_RGB8_ETC2, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
-			expectError				(GL_INVALID_ENUM);
-			m_log << TestLog::EndSection;
+				glGetInternalformativ	(GL_RENDERBUFFER, GL_COMPRESSED_RGB8_ETC2, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
+				expectError				(GL_INVALID_ENUM);
+				m_log << TestLog::EndSection;
+			}
 
 			m_log << TestLog::Section("", "GL_INVALID_ENUM is generated if target is not GL_RENDERBUFFER.");
 			glGetInternalformativ	(-1, GL_RGBA8, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
@@ -962,7 +966,7 @@ void NegativeStateApiTests::init (void)
 			glGetInternalformativ	(GL_FRAMEBUFFER, GL_RGBA8, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
 			expectError				(GL_INVALID_ENUM);
 
-			if (!m_context.getContextInfo().isExtensionSupported("GL_EXT_sparse_texture"))
+			if (isES && !m_context.getContextInfo().isExtensionSupported("GL_EXT_sparse_texture"))
 			{
 				glGetInternalformativ	(GL_TEXTURE_2D, GL_RGBA8, GL_NUM_SAMPLE_COUNTS, 16, &params[0]);
 				expectError				(GL_INVALID_ENUM);

--- a/modules/gles3/functional/es3fNegativeTextureApiTests.cpp
+++ b/modules/gles3/functional/es3fNegativeTextureApiTests.cpp
@@ -403,55 +403,58 @@ void NegativeTextureApiTests::init (void)
 		});
 	ES3F_ADD_API_CASE(compressedteximage2d_invalid_border, "Invalid glCompressedTexImage2D() usage",
 		{
+			bool	isES = glu::isContextTypeES(m_context.getRenderContext().getType());
+			GLenum	error = isES ? GL_INVALID_VALUE : GL_INVALID_OPERATION;
+
 			m_log << TestLog::Section("", "GL_INVALID_VALUE is generated if border is not 0.");
 
 			m_log << TestLog::Section("", "GL_TEXTURE_2D target");
 			glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_POSITIVE_X target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_POSITIVE_Y target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_POSITIVE_Z target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_NEGATIVE_X target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_NEGATIVE_Y target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_TEXTURE_CUBE_MAP_NEGATIVE_Z target");
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::EndSection;
@@ -1052,29 +1055,32 @@ void NegativeTextureApiTests::init (void)
 			expectError(GL_INVALID_OPERATION);
 			m_log << TestLog::EndSection;
 
-			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the zero level array is stored in a compressed internal format.");
-			glBindTexture(GL_TEXTURE_2D, texture[1]);
-			glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 0, 0, 0);
-			glGenerateMipmap(GL_TEXTURE_2D);
-			expectError(GL_INVALID_OPERATION);
-			m_log << TestLog::EndSection;
-
-			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the level base array was not specified with an unsized internal format or a sized internal format that is both color-renderable and texture-filterable.");
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8_SNORM, 0, 0, 0, GL_RGB, GL_BYTE, 0);
-			glGenerateMipmap(GL_TEXTURE_2D);
-			expectError(GL_INVALID_OPERATION);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_R8I, 0, 0, 0, GL_RED_INTEGER, GL_BYTE, 0);
-			glGenerateMipmap(GL_TEXTURE_2D);
-			expectError(GL_INVALID_OPERATION);
-
-			if (!(m_context.getContextInfo().isExtensionSupported("GL_EXT_color_buffer_float") && m_context.getContextInfo().isExtensionSupported("GL_OES_texture_float_linear")))
+			if (glu::isContextTypeES(m_context.getRenderContext().getType()))
 			{
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, 0, 0, 0, GL_RGBA, GL_FLOAT, 0);
+				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the zero level array is stored in a compressed internal format.");
+				glBindTexture(GL_TEXTURE_2D, texture[1]);
+				glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 0, 0, 0);
 				glGenerateMipmap(GL_TEXTURE_2D);
 				expectError(GL_INVALID_OPERATION);
-			}
+				m_log << TestLog::EndSection;
 
-			m_log << TestLog::EndSection;
+				m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the level base array was not specified with an unsized internal format or a sized internal format that is both color-renderable and texture-filterable.");
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8_SNORM, 0, 0, 0, GL_RGB, GL_BYTE, 0);
+				glGenerateMipmap(GL_TEXTURE_2D);
+				expectError(GL_INVALID_OPERATION);
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_R8I, 0, 0, 0, GL_RED_INTEGER, GL_BYTE, 0);
+				glGenerateMipmap(GL_TEXTURE_2D);
+				expectError(GL_INVALID_OPERATION);
+
+				if (!(m_context.getContextInfo().isExtensionSupported("GL_EXT_color_buffer_float") && m_context.getContextInfo().isExtensionSupported("GL_OES_texture_float_linear")))
+				{
+					glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, 0, 0, 0, GL_RGBA, GL_FLOAT, 0);
+					glGenerateMipmap(GL_TEXTURE_2D);
+					expectError(GL_INVALID_OPERATION);
+				}
+
+				m_log << TestLog::EndSection;
+			}
 
 			glDeleteTextures(2, texture);
 		});
@@ -1141,16 +1147,19 @@ void NegativeTextureApiTests::init (void)
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the combination of internalFormat, format and type is invalid.");
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-			expectError(GL_INVALID_OPERATION);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGB, GL_UNSIGNED_SHORT_4_4_4_4, 0);
 			expectError(GL_INVALID_OPERATION);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB5_A1, 1, 1, 0, GL_RGB, GL_UNSIGNED_SHORT_5_5_5_1, 0);
 			expectError(GL_INVALID_OPERATION);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB10_A2, 1, 1, 0, GL_RGB, GL_UNSIGNED_INT_2_10_10_10_REV, 0);
 			expectError(GL_INVALID_OPERATION);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32UI, 1, 1, 0, GL_RGBA_INTEGER, GL_INT, 0);
-			expectError(GL_INVALID_OPERATION);
+			if (glu::isContextTypeES(m_context.getRenderContext().getType()))
+			{
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+				expectError(GL_INVALID_OPERATION);
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32UI, 1, 1, 0, GL_RGBA_INTEGER, GL_INT, 0);
+				expectError(GL_INVALID_OPERATION);
+			}
 			m_log << TestLog::EndSection;
 		});
 	ES3F_ADD_API_CASE(teximage2d_inequal_width_height_cube, "Invalid glTexImage2D() usage",
@@ -1451,8 +1460,11 @@ void NegativeTextureApiTests::init (void)
 			expectError(GL_INVALID_OPERATION);
 			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_RGBA_INTEGER, GL_UNSIGNED_INT, 0);
 			expectError(GL_INVALID_OPERATION);
-			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_RGB, GL_FLOAT, 0);
-			expectError(GL_INVALID_OPERATION);
+			if (glu::isContextTypeES(m_context.getRenderContext().getType()))
+			{
+				glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_RGB, GL_FLOAT, 0);
+				expectError(GL_INVALID_OPERATION);
+			}
 			m_log << tcu::TestLog::EndSection;
 
 			glDeleteTextures	(1, &texture);
@@ -2072,16 +2084,19 @@ void NegativeTextureApiTests::init (void)
 			m_log << TestLog::EndSection;
 
 			m_log << TestLog::Section("", "GL_INVALID_OPERATION is generated if the combination of internalFormat, format and type is invalid.");
-			glTexImage3D(GL_TEXTURE_3D, 0, GL_RGB, 1, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-			expectError(GL_INVALID_OPERATION);
 			glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 1, 1, 1, 0, GL_RGB, GL_UNSIGNED_SHORT_4_4_4_4, 0);
 			expectError(GL_INVALID_OPERATION);
 			glTexImage3D(GL_TEXTURE_3D, 0, GL_RGB5_A1, 1, 1, 1, 0, GL_RGB, GL_UNSIGNED_SHORT_5_5_5_1, 0);
 			expectError(GL_INVALID_OPERATION);
 			glTexImage3D(GL_TEXTURE_3D, 0, GL_RGB10_A2, 1, 1, 1, 0, GL_RGB, GL_UNSIGNED_INT_2_10_10_10_REV, 0);
 			expectError(GL_INVALID_OPERATION);
-			glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA32UI, 1, 1, 1, 0, GL_RGBA_INTEGER, GL_INT, 0);
-			expectError(GL_INVALID_OPERATION);
+			if (glu::isContextTypeES(m_context.getRenderContext().getType()))
+			{
+				glTexImage3D(GL_TEXTURE_3D, 0, GL_RGB, 1, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+				expectError(GL_INVALID_OPERATION);
+				glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA32UI, 1, 1, 1, 0, GL_RGBA_INTEGER, GL_INT, 0);
+				expectError(GL_INVALID_OPERATION);
+			}
 			m_log << TestLog::EndSection;
 		});
 	ES3F_ADD_API_CASE(teximage3d_neg_level, "Invalid glTexImage3D() usage",
@@ -2245,8 +2260,11 @@ void NegativeTextureApiTests::init (void)
 			expectError(GL_INVALID_OPERATION);
 			glTexSubImage3D(GL_TEXTURE_3D, 0, 0, 0, 0, 4, 4, 4, GL_RGBA_INTEGER, GL_UNSIGNED_INT, 0);
 			expectError(GL_INVALID_OPERATION);
-			glTexSubImage3D(GL_TEXTURE_3D, 0, 0, 0, 0, 4, 4, 4, GL_RGB, GL_FLOAT, 0);
-			expectError(GL_INVALID_OPERATION);
+			if (glu::isContextTypeES(m_context.getRenderContext().getType()))
+			{
+				glTexSubImage3D(GL_TEXTURE_3D, 0, 0, 0, 0, 4, 4, 4, GL_RGB, GL_FLOAT, 0);
+				expectError(GL_INVALID_OPERATION);
+			}
 			m_log << tcu::TestLog::EndSection;
 
 			glDeleteTextures	(1, &texture);
@@ -2621,11 +2639,14 @@ void NegativeTextureApiTests::init (void)
 		});
 	ES3F_ADD_API_CASE(compressedteximage3d_invalid_border, "Invalid glCompressedTexImage3D() usage",
 		{
+			bool	isES = glu::isContextTypeES(m_context.getRenderContext().getType());
+			GLenum	error = isES ? GL_INVALID_VALUE : GL_INVALID_OPERATION;
+
 			m_log << TestLog::Section("", "GL_INVALID_VALUE is generated if border is not 0.");
 			glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 0, -1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 0, 1, 0, 0);
-			expectError(GL_INVALID_VALUE);
+			expectError(error);
 			m_log << TestLog::EndSection;
 		});
 	ES3F_ADD_API_CASE(compressedteximage3d_invalid_size, "Invalid glCompressedTexImage3D() usage",


### PR DESCRIPTION
This patch is port of 512fa1c1bc1930a1966df7caefb3c199ac02a919

Affects:
dEQP-GL45-ES3.functional.negative_api.*
dEQP-GLES3.functional.negative_api.*

Signed-off-by: Mykola Piatykop <mykola.piatykop@globallogic.com>