### PR TITLE
A PR from wenkezh

### DIFF
--- a/external/openglcts/modules/gles31/es31cArrayOfArraysTests.cpp
+++ b/external/openglcts/modules/gles31/es31cArrayOfArraysTests.cpp
@@ -1002,6 +1002,59 @@ tcu::TestNode::IterateResult TestCaseBase<API>::execute_positive_test(const std:
 
 	return CONTINUE;
 }
+	
+/** 
+The number of active shader storage blocks referenced by the shaders in a program implementation dependent and cannot exceeds implementation-dependent limits
+The limits for vertex, tessellation control, tessellation evaluation and geometry can be obtained by calling GetIntegerv with pname values of MAX_VERTEX_SHADER_STORAGE_BLOCKS,
+MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS, MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS and MAX_GEOMETRY_SHADER_STORAGE_BLOCKS, respectively.
+*/
+template <class API>
+tcu::TestNode::IterateResult TestCaseBase<API>::limit_active_shader_storage_block_number(
+	typename TestCaseBase<API>::TestShaderType tested_shader_type, size_t num)
+{
+	const glw::Functions& gl = context_id.getRenderContext().getFunctions();
+	glw::GLint res;
+
+	switch (tested_shader_type)
+	{
+	case TestCaseBase<API>::VERTEX_SHADER_TYPE:
+		gl.getIntegerv(GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &res);
+		if (res < num)
+		{
+			tcu::NotSupportedError(
+				"The number of active vertex shader storage blocks exceeds implementation-dependent limits.");
+			return STOP;
+		}
+		break;
+	case TestCaseBase<API>::TESSELATION_CONTROL_SHADER_TYPE:
+		gl.getIntegerv(GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS, &res);
+		if (res < num)
+		{
+			tcu::NotSupportedError("The number of active TC shader storage blocks exceeds implementation-dependent limits.");
+			return STOP;
+		}
+		break;
+	case TestCaseBase<API>::TESSELATION_EVALUATION_SHADER_TYPE:
+		gl.getIntegerv(GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS, &res);
+		if (res < num)
+		{
+			tcu::NotSupportedError("The number of active TE shader storage blocks exceeds implementation-dependent limits.");
+			return STOP;
+		}
+		break;
+	case TestCaseBase<API>::GEOMETRY_SHADER_TYPE:
+		gl.getIntegerv(GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS, &res);
+		if (res < num)
+		{
+			tcu::NotSupportedError("The number of active geometry shader storage blocks exceeds implementation-dependent limits.");
+			return STOP;
+		}
+		break;
+	default:
+		break;
+	}
+	return CONTINUE;
+}
 
 /** Runs the positive test.
  *  The shader sources are considered as valid,

--- a/external/openglcts/modules/gles31/es31cArrayOfArraysTests.hpp
+++ b/external/openglcts/modules/gles31/es31cArrayOfArraysTests.hpp
@@ -292,6 +292,9 @@ protected:
 															   const std::string& compute_shader_source,
 															   bool delete_generated_objects, bool require_gpu_shader5);
 
+    virtual tcu::TestNode::IterateResult limit_active_shader_storage_block_number(
+		typename TestCaseBase<API>::TestShaderType tested_shader_type, size_t number_of_blocks);
+
 	virtual void test_shader_compilation(typename TestCaseBase<API>::TestShaderType tested_shader_type) = 0;
 
 	/* Protected fields */


### PR DESCRIPTION
A Solution to issue 324: "KHR-GL46.arrays_of_arrays_gl.InteractionInterfaceArrays1" tests shader storage buffer object array of arrays in all 6 stages of pipeline. 4 ssbo instances declared in each shader, and CTS expect a successful compilation and link. But ogl spec doesn't require vertex/tessellation/geometry shaders to support 4 ssbos. It's implementation dependent and cannot exceeds implementation-dependent limits. The limits for vertex, tessellation control, tessellation evaluation and geometry can be obtained by calling GetIntegerv with pname values of MAX_VERTEX_SHADER_STORAGE_BLOCKS,
MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS, MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS and MAX_GEOMETRY_SHADER_STORAGE_BLOCKS, respectively.