### PR TITLE
Use Mach semaphores on Darwin

### DIFF
--- a/framework/delibs/dethread/CMakeLists.txt
+++ b/framework/delibs/dethread/CMakeLists.txt
@@ -20,7 +20,7 @@ set(DETHREAD_SRCS
 	win32/deThreadWin32.c
 	win32/deThreadLocalWin32.c
 	unix/deMutexUnix.c
-	unix/deNamedSemaphoreUnix.c
+	unix/deSemaphoreMach.c
 	unix/deSemaphoreUnix.c
 	unix/deThreadUnix.c
 	unix/deThreadLocalUnix.c


### PR DESCRIPTION
Using named POSIX semaphores presents a problem: since they are visible
to other processes, they don't get cleaned up automatically when the
process dies. This causes problems down the line when the POSIX
semaphore namespace is filled up (macOS, by default, only allows 10000
POSIX semaphores to exist at once): creating new semaphores fails, and
thus we die with a null pointer reference when we try to use the
semaphore.

Mach semaphores have none of these problems. And no, I have no idea why
Apple doesn't just implement anonymous POSIX semaphores on top of Mach
semaphores. Maybe they thought it would be too hard to distinguish named
from unnamed semaphores?

Components: Framework
Change-Id: Id2b5a05b8afe96c5d9999417b0fcd1f96ddb7ba3