### PR TITLE
Fix build in C++20 mode.

### DIFF
--- a/framework/common/tcuThreadUtil.cpp
+++ b/framework/common/tcuThreadUtil.cpp
@@ -61,7 +61,7 @@ Event::Result Event::waitReady (void)
 	m_lock.lock();
 
 	if (m_result == RESULT_NOT_READY)
-		m_waiterCount++;
+		m_waiterCount = m_waiterCount + 1;
 	else
 	{
 		m_lock.unlock();

--- a/framework/delibs/decpp/deSpinBarrier.cpp
+++ b/framework/delibs/decpp/deSpinBarrier.cpp
@@ -102,12 +102,12 @@ void SpinBarrier::sync (WaitMode requestedMode)
 	{
 		// Release all waiting threads. Since this thread has not been removed, m_numLeaving will
 		// be >= 1 until m_numLeaving is decremented at the end of this function.
-		m_numThreads -= m_numRemoved;
-		m_numLeaving  = m_numThreads;
-		m_numRemoved  = 0;
+		m_numThreads = m_numThreads - m_numRemoved;
+		m_numLeaving = m_numThreads;
+		m_numRemoved = 0;
 
 		deMemoryReadWriteFence();
-		m_numEntered  = 0;
+		m_numEntered = 0;
 	}
 	else
 	{
@@ -148,12 +148,12 @@ void SpinBarrier::removeThread (WaitMode requestedMode)
 	if (deAtomicIncrement32(&m_numEntered) == cachedNumThreads)
 	{
 		// Release all waiting threads.
-		m_numThreads -= m_numRemoved;
-		m_numLeaving  = m_numThreads;
-		m_numRemoved  = 0;
+		m_numThreads = m_numThreads - m_numRemoved;
+		m_numLeaving = m_numThreads;
+		m_numRemoved = 0;
 
 		deMemoryReadWriteFence();
-		m_numEntered  = 0;
+		m_numEntered = 0;
 	}
 }
 

--- a/framework/randomshaders/rsgExecutionContext.hpp
+++ b/framework/randomshaders/rsgExecutionContext.hpp
@@ -34,10 +34,7 @@
 namespace rsg
 {
 
-enum
-{
-	EXEC_VEC_WIDTH	= 64
-};
+constexpr int EXEC_VEC_WIDTH = 64;
 
 typedef ConstStridedValueAccess<EXEC_VEC_WIDTH>			ExecConstValueAccess;
 typedef StridedValueAccess<EXEC_VEC_WIDTH>				ExecValueAccess;

--- a/framework/referencerenderer/rrFragmentPacket.hpp
+++ b/framework/referencerenderer/rrFragmentPacket.hpp
@@ -29,10 +29,7 @@
 namespace rr
 {
 
-enum
-{
-	NUM_FRAGMENTS_PER_PACKET	= 4
-};
+constexpr int NUM_FRAGMENTS_PER_PACKET = 4;
 
 /*--------------------------------------------------------------------*//*!
  * \brief Fragment packet

--- a/modules/glshared/glsBuiltinPrecisionTests.cpp
+++ b/modules/glshared/glsBuiltinPrecisionTests.cpp
@@ -653,33 +653,6 @@ private:
 	int		m_count;
 };
 
-class ExpandContext
-{
-public:
-						ExpandContext	(Counter& symCounter) : m_symCounter(symCounter) {}
-						ExpandContext	(const ExpandContext& parent)
-							: m_symCounter(parent.m_symCounter) {}
-
-	template<typename T>
-	VariableP<T>		genSym			(const string& baseName)
-	{
-		return variable<T>(baseName + de::toString(m_symCounter()));
-	}
-
-	void				addStatement	(const StatementP& stmt)
-	{
-		m_statements.push_back(stmt);
-	}
-
-	vector<StatementP>	getStatements	(void) const
-	{
-		return m_statements;
-	}
-private:
-	Counter&			m_symCounter;
-	vector<StatementP>	m_statements;
-};
-
 /*--------------------------------------------------------------------*//*!
  * \brief A statement or declaration.
  *
@@ -726,6 +699,33 @@ public:
 				StatementP			(void) {}
 	explicit	StatementP			(const Statement* ptr)	: Super(ptr) {}
 				StatementP			(const Super& ptr)		: Super(ptr) {}
+};
+
+class ExpandContext
+{
+public:
+						ExpandContext	(Counter& symCounter) : m_symCounter(symCounter) {}
+						ExpandContext	(const ExpandContext& parent)
+							: m_symCounter(parent.m_symCounter) {}
+
+	template<typename T>
+	VariableP<T>		genSym			(const string& baseName)
+	{
+		return variable<T>(baseName + de::toString(m_symCounter()));
+	}
+
+	void				addStatement	(const StatementP& stmt)
+	{
+		m_statements.push_back(stmt);
+	}
+
+	vector<StatementP>	getStatements	(void) const
+	{
+		return m_statements;
+	}
+private:
+	Counter&			m_symCounter;
+	vector<StatementP>	m_statements;
 };
 
 /*--------------------------------------------------------------------*//*!


### PR DESCRIPTION
* Compound assignments to volatiles are deprecated.  Use non-compound forms.
* Math between disparate enums is deprecated.  Use constexprs.
* The full definition of a type T must be visible for code that instantiates std::vector<T>.  Reorder code to guarantee this.

Bug: chromium:1284275