### PR TITLE
Update zlib dependency

### DIFF
--- a/external/fetch_sources.py
+++ b/external/fetch_sources.py
@@ -281,9 +281,9 @@ def postExtractLibpng (path):
 
 PACKAGES = [
 	SourcePackage(
-		"http://zlib.net/zlib-1.2.12.tar.gz",
-		"zlib-1.2.12.tar.gz",
-		"91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+		"http://zlib.net/fossils/zlib-1.2.13.tar.gz",
+		"zlib-1.2.13.tar.gz",
+		"b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
 		"zlib"),
 	SourcePackage(
 		"http://prdownloads.sourceforge.net/libpng/libpng-1.6.27.tar.gz",


### PR DESCRIPTION
A new version addressing a security issue has been released, and the existing URL isn't valid any more.

Update to 1.2.13 and take the chance to switch to an archive URL, that should be more stable going forward.