### PR TITLE
Add RISC-V support.

### DIFF
--- a/framework/delibs/debase/deDefs.c
+++ b/framework/delibs/debase/deDefs.c
@@ -38,7 +38,7 @@ DE_STATIC_ASSERT(sizeof(deIntptr)	== sizeof(void*));
 DE_STATIC_ASSERT(DE_PTR_SIZE		== sizeof(void*));
 
 /* Sanity checks for DE_PTR_SIZE & DE_CPU */
-#if !((DE_CPU == DE_CPU_X86_64 || DE_CPU == DE_CPU_ARM_64 || DE_CPU == DE_CPU_MIPS_64) && (DE_PTR_SIZE == 8)) && \
+#if !((DE_CPU == DE_CPU_X86_64 || DE_CPU == DE_CPU_ARM_64 || DE_CPU == DE_CPU_MIPS_64 || DE_CPU == DE_CPU_RISCV_64) && (DE_PTR_SIZE == 8)) && \
 	!((DE_CPU == DE_CPU_X86    || DE_CPU == DE_CPU_ARM    || DE_CPU == DE_CPU_MIPS)    && (DE_PTR_SIZE == 4))
 #	error "DE_CPU and DE_PTR_SIZE mismatch"
 #endif

--- a/framework/delibs/debase/deDefs.h
+++ b/framework/delibs/debase/deDefs.h
@@ -109,6 +109,7 @@
 #define DE_CPU_ARM_64	4
 #define DE_CPU_MIPS		5
 #define DE_CPU_MIPS_64	6
+#define DE_CPU_RISCV_64	7
 
 /* CPU detection. */
 #if defined(DE_CPU)
@@ -125,6 +126,8 @@
 #	define DE_CPU DE_CPU_MIPS
 #elif defined(__mips__) && ((__mips) == 64)
 #	define DE_CPU DE_CPU_MIPS_64
+#elif defined(__riscv) && ((__riscv_xlen) == 64)
+#	define DE_CPU DE_CPU_RISCV_64
 #else
 #	error Unknown CPU.
 #endif


### PR DESCRIPTION
Android is adding RISC-V support to AOSP, but only for 64-bit RISC-V (which is why there's no 32-bit constant or logic here).

Signed-off-by: Mao Han <han_mao@linux.alibaba.com>