### PR TITLE
Allow override of wayland_scanner executable

### DIFF
--- a/framework/platform/CMakeLists.txt
+++ b/framework/platform/CMakeLists.txt
@@ -74,7 +74,10 @@ if (NOT DEFINED TCUTIL_PLATFORM_SRCS)
 			include_directories(lnx/wayland)
 
 			pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
-			pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+
+			if (NOT WAYLAND_SCANNER)
+				pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+			endif()
 
 			set(DEQP_XDG_SHELL_PROTOCOL ${WAYLAND_PROTOCOLS_DIR}/stable/xdg-shell/xdg-shell.xml)
 			set(DEQP_XDG_SHELL_GEN_OUTPUTS_DIR ${PROJECT_BINARY_DIR}/framework/platform)


### PR DESCRIPTION
When cross-compiling, if the environment variables PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_LIBDIR are set to the target sysroot, the wayland_scanner executable won't be found and the compilation will fail as the xdg-shell header cannot be generated. Therefore, allow overriding the wayland_scanner executable so that an alternative executable can be provided with the variable WAYLAND_SCANNER.