### PR TITLE
Fix compilation error in ANGLE

### DIFF
--- a/external/openglcts/modules/common/glcPackedPixelsTests.cpp
+++ b/external/openglcts/modules/common/glcPackedPixelsTests.cpp
@@ -1259,7 +1259,7 @@ void RectangleTest::makeGradient(Type (*unpack)(float))
 					(j < m_unpackProperties.skipRows + GRADIENT_HEIGHT) && (m_unpackProperties.skipPixels <= x) &&
 					(x < m_unpackProperties.skipPixels + GRADIENT_WIDTH))
 				{
-					float value   = static_cast<float>(x - m_unpackProperties.skipPixels) / GRADIENT_WIDTH;
+					float value   = static_cast<float>(x - m_unpackProperties.skipPixels) / static_cast<float> (GRADIENT_WIDTH);
 					int   channel = i - elementsInGroup * x;
 					value *= 1.0f - 0.25f * channel;
 					data[index] = unpack(value);


### PR DESCRIPTION
ANGLE throws below compliation warnings in win-msvc* build bots:
glcPackedPixelsTests.cpp(1262): error C2220: the following warning is treated as an error glcPackedPixelsTests.cpp(1262): warning C5055: operator '/': deprecated between enumerations and floating-point types

Add a static_cast to the enum GRADIENT_WIDTH to suppress the compilation warning.