### PR TITLE
Add missing buffer memory flush

### DIFF
--- a/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
+++ b/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
@@ -423,6 +423,7 @@ void clearBuffer (const DeviceInterface& vk, const VkDevice device, const de::Sh
 	void*						allocationData	= allocation.getHostPtr();
 	invalidateAlloc(vk, device, allocation);
 	deMemcpy(allocationData, &data[0], (size_t)bufferSizeBytes);
+	flushAlloc(vk, device, allocation);
 }
 
 class StatisticQueryTestInstance : public TestInstance


### PR DESCRIPTION
This PR is related to a bug that was originally submitted as a [mesa issue](https://gitlab.freedesktop.org/mesa/mesa/-/issues/6213), but I believe it's actually a test bug.

We do a memcpy to the buffer, but don't flush it after writing.
If we don't use host-coherent memory for this buffer it might sometimes lead to corruption (when we later invalidate the buffer's memory to get results from the shader).

According to `vkInvalidateMappedMemoryRanges` spec:
> If a range of non-coherent memory is written by the host and then invalidated without first being flushed, its contents are undefined.
