### PR TITLE
vulkancts: Include missing <cstdint>

### DIFF
--- a/external/vulkancts/modules/vulkan/spirv_assembly/vktSpvAsmFloatControlsTests.cpp
+++ b/external/vulkancts/modules/vulkan/spirv_assembly/vktSpvAsmFloatControlsTests.cpp
@@ -33,6 +33,7 @@
 #include "deFloat16.h"
 #include "vkQueryUtil.hpp"
 #include "vkRefUtil.hpp"
+#include <cstdint>
 #include <cstring>
 #include <vector>
 #include <limits>

--- a/framework/common/tcuDefs.hpp
+++ b/framework/common/tcuDefs.hpp
@@ -26,6 +26,7 @@
 #include "deDefs.hpp"
 #include "qpTestLog.h"
 
+#include <cstdint>
 #include <string>
 #include <stdexcept>
 


### PR DESCRIPTION
Fixes build with gcc-13

../git/external/vulkancts/modules/vulkan/spirv_assembly/vktSpvAsmFloatControlsTests.cpp:2798:102: error: 'uintptr_t' in namespace 'std' does not name a type
 2798 |                 BufferDataType type              = static_cast<BufferDataType>(reinterpret_cast<std::uintptr_t>(expectedOutputs[resultIndex].getUserData()));
      |                                                                                                      ^~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>