### PR TITLE
Fix g8_b8r8_2plane_420_unorm checks with VIDEO formats

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
@@ -3805,6 +3805,11 @@ VkFormatFeatureFlags getAllowedOptimalTilingFeatures (Context &context, VkFormat
 	// Formats for which SamplerYCbCrConversion is required may not support certain features.
 	if (requiresYCbCrConversion(context, format))
 		allow &= ycbcrAllows;
+
+#ifndef CTS_USES_VULKANSC
+    allow |= VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR | VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR;
+#endif
+
 	// single-plane formats *may not* support DISJOINT_BIT
 	if (!isYCbCrFormat(format) || getPlaneCount(format) == 1)
 		allow &= ~VK_FORMAT_FEATURE_DISJOINT_BIT;


### PR DESCRIPTION
Issue on mesa (Linux Intel GPU)
https://gitlab.freedesktop.org/mesa/mesa/-/issues/8263

It's not considering that those bits can be present for any format.

```
Test case 'dEQP-VK.api.info.format_properties.g8_b8r8_2plane_420_unorm'..
  Fail (linearTilingFeatures: has: VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR|VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR)
```