### PR TITLE
Correct the OGL 3.1 core profile creation logic.

### DIFF
--- a/external/openglcts/modules/gl/gl3cTestPackages.hpp
+++ b/external/openglcts/modules/gl/gl3cTestPackages.hpp
@@ -53,7 +53,7 @@ class GL31TestPackage : public GL30TestPackage
 public:
 	GL31TestPackage(tcu::TestContext& testCtx, const char* packageName,
 					const char*		 description	   = "OpenGL 3.1 Conformance Tests",
-					glu::ContextType renderContextType = glu::ContextType(3, 1, glu::PROFILE_CORE));
+					glu::ContextType renderContextType = glu::ContextType(3, 1, glu::PROFILE_CORE, glu::CONTEXT_FORWARD_COMPATIBLE));
 
 	~GL31TestPackage(void);
 


### PR DESCRIPTION
For the OGL 3.1 context, if we want to use the "core profile", we need to config the "GLX_CONTEXT_FLAGS_ARB" to " GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB".