### PR TITLE
Don't include windows.h in the vk namespace

### DIFF
--- a/external/vulkancts/framework/vulkan/vkStrUtil.cpp
+++ b/external/vulkancts/framework/vulkan/vkStrUtil.cpp
@@ -23,6 +23,13 @@
 
 #include "vkStrUtil.hpp"
 
+#if (DE_OS == DE_OS_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#endif
+
 namespace vk
 {
 
@@ -48,9 +55,6 @@ inline CharPtr getCharPtrStr (const char* ptr)
 
 
 #if (DE_OS == DE_OS_WIN32)
-
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 
 struct WStr
 {


### PR DESCRIPTION
This causes problems when building for arm64. Compiler errors for interlocked ops start to appear pointing at winbase.h.