### PR TITLE
Require a more recent version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 # dEQP cmake file
 
 # Module FindGit requires cmake >= 2.8.2
-cmake_minimum_required(VERSION 3.17.2)
+# Using AFTER in target_include_directories requires >= 3.20.6
+cmake_minimum_required(VERSION 3.20.6)
 
 option(GLES_ALLOW_DIRECT_LINK "Allow direct linking to GLES libraries" ON)
 


### PR DESCRIPTION
The change 635ab10334da802e9f110c467fc99857a0fda624 added use of this new feature - update the required version of cmake so that the build fails earlier and more obviously.