### PR TITLE
Add missing src buffer flush and dst buffer invalidation

### DIFF
--- a/external/vulkancts/modules/vulkan/image/vktImageTransfer.cpp
+++ b/external/vulkancts/modules/vulkan/image/vktImageTransfer.cpp
@@ -192,6 +192,7 @@ tcu::TestStatus TransferQueueInstance::iterate (void)
 		fillRandomNoNaN(&randomGen, generatedData.data(), (deUint32)generatedData.size(), m_params.imageFormat);
 		const Allocation& alloc = srcBuffer.getAllocation();
 		deMemcpy(alloc.getHostPtr(), generatedData.data(), generatedData.size());
+		flushAlloc(vk, device, alloc);
 	}
 
 	beginCommandBuffer(vk, *m_cmdBuffer);
@@ -252,6 +253,7 @@ tcu::TestStatus TransferQueueInstance::iterate (void)
 	{
 		std::vector<deUint8> resultData(pixelDataSize);
 		const Allocation& alloc = dstBuffer.getAllocation();
+		invalidateAlloc(vk, device, alloc);
 		deMemcpy(resultData.data(), alloc.getHostPtr(), resultData.size());
 
 		for (uint32_t i = 0; i < pixelDataSize; ++i) {


### PR DESCRIPTION
This PR is related to a bug that was originally submitted as a [mesa issue](https://gitlab.freedesktop.org/mesa/mesa/-/issues/9088), but I believe it's actually a test bug.
(similar to the one fixed in https://github.com/KhronosGroup/VK-GL-CTS/pull/372).

We allocate and map src/dst buffers, write data to src, and read it from dst. But we don't flush src buffer after writing or invalidate dst buffer before reading. So if we allocate those buffers from non-host-coherent memory, the data may be corrupted at both of those steps.