### PR TITLE
Test alpha-less 10bit formats correctly in wide_color tests

### DIFF
--- a/modules/egl/teglWideColorTests.cpp
+++ b/modules/egl/teglWideColorTests.cpp
@@ -582,7 +582,7 @@ protected:
 	void				readPixels					(const glw::Functions& gl, deUint32* dataPtr);
 	void				readPixels					(const glw::Functions& gl, deUint8* dataPtr);
 	deUint32			expectedUint10					(float reference);
-	deUint32			expectedUint2					(float reference);
+	deUint32			expectedAlpha2					(float reference);
 	deUint8				expectedUint8					(float reference);
 	deUint8				expectedAlpha8					(float reference);
 	bool				checkWithThreshold8				(deUint8 value, deUint8 reference, deUint8 threshold = 1);
@@ -854,11 +854,16 @@ deUint32 WideColorSurfaceTest::expectedUint10 (float reference)
 	return expected;
 }
 
-deUint32 WideColorSurfaceTest::expectedUint2 (float reference)
+deUint32 WideColorSurfaceTest::expectedAlpha2 (float reference)
 {
 	deUint32 expected;
 
-	if (reference < 0.0)
+	if (m_alphaSize == 0)
+	{
+		// Surfaces without alpha are read back as opaque.
+		expected = 3;
+	}
+	else if (reference < 0.0)
 	{
 		expected = 0;
 	}
@@ -1029,7 +1034,7 @@ void WideColorSurfaceTest::testPixels (float reference, float increment)
 		expected[0] = expectedUint10(reference);
 		expected[1] = expectedUint10(reference + increment);
 		expected[2] = expectedUint10(reference - increment);
-		expected[3] = expectedUint2(reference + 2 * increment);
+		expected[3] = expectedAlpha2(reference + 2 * increment);
 		if (checkWithThreshold10(pixels[0], expected[0]) || checkWithThreshold10(pixels[1], expected[1])
 				|| checkWithThreshold10(pixels[2], expected[2]) || checkWithThreshold10(pixels[3], expected[3]))
 		{


### PR DESCRIPTION
The test for alpha for 10bit formats did not take 'EGL_ALPHA_SIZE == 0' into account. This is expected to read back as opaque. Fixes dEQP-EGL.functional.wide_color.{pbuffer,window}_888* when a 10bit format is selected. Seen when using wayland as target.

Fixes If0541906e510b3c2191a3e9ca8be3eb2529a0475

Components: EGL

Affects:

dEQP-EGL.functional.wide_color.window_888_colorspace_default
dEQP-EGL.functional.wide_color.window_888_colorspace_srgb
dEQP-EGL.functional.wide_color.window_888_colorspace_p3
dEQP-EGL.functional.wide_color.window_888_colorspace_p3_passthrough
dEQP-EGL.functional.wide_color.pbuffer_888_colorspace_default
dEQP-EGL.functional.wide_color.pbuffer_888_colorspace_srgb
dEQP-EGL.functional.wide_color.pbuffer_888_colorspace_p3
dEQP-EGL.functional.wide_color.pbuffer_888_colorspace_p3_passthrough