### PR TITLE
Let cts can skip commented cases in caselist file

### DIFF
--- a/framework/common/tcuCommandLine.cpp
+++ b/framework/common/tcuCommandLine.cpp
@@ -498,6 +498,15 @@ static void parseCaseList (CaseTreeNode* root, std::istream& in)
 		}
 		else if (isValidTestCaseNameChar((char)curChr))
 			curName += (char)curChr;
+		else if (curChr == '#') {
+			int curChr_tmp = curChr;
+			while (curChr_tmp != '\n') {
+				curChr_tmp = in.get();
+				curName += (char)curChr_tmp;
+			}
+			std::cout << "Skip test case: " << curName << "\n";
+			curName.clear();
+		}
 		else
 			throw std::invalid_argument("Illegal character in test case name");
 	}


### PR DESCRIPTION
Add a new else if in parseCaseList() to skip commented line of caselist file. With this we can skip some less important test cases that may cause system hang or crash and let the whole test finish.