### PR TITLE
script: fixes shellquote

### DIFF
--- a/scripts/ctsbuild/common.py
+++ b/scripts/ctsbuild/common.py
@@ -68,7 +68,7 @@ def die (msg):
 	exit(-1)
 
 def shellquote(s):
-	return '"%s"' % s.replace('\\', '\\\\').replace('"', '\"').replace('$', '\$').replace('`', '\`')
+	return '"%s"' % s.replace('\\', '\\\\').replace('"', '\"').replace('$', '\\$').replace('`', '\\`')
 
 g_workDirStack = []
 


### PR DESCRIPTION
C:\src\VK-GL-CTS\external\..\scripts\build\common.py:70: SyntaxWarning: invalid escape sequence '\$'
  return '"%s"' % s.replace('\\', '\\\\').replace('"', '\"').replace('$', '\$').replace('`', '\`')
C:\src\VK-GL-CTS\external\..\scripts\build\common.py:70: SyntaxWarning: invalid escape sequence '\`'
  return '"%s"' % s.replace('\\', '\\\\').replace('"', '\"').replace('$', '\$').replace('`', '\`')