### PR TITLE
Fix egl_fence_persistent_buffer deinit on GLES 2.0

### DIFF
--- a/modules/egl/teglSyncTests.cpp
+++ b/modules/egl/teglSyncTests.cpp
@@ -413,7 +413,9 @@ class CreateLongRunningSyncTest : public SyncTest {
 	{
 		const Library& egl = m_eglTestCtx.getLibrary();
 
-		m_gl.useProgram(0);
+		if (m_gl.useProgram)
+			m_gl.useProgram(0);
+
 		if (m_buffer != 0) {
 			m_gl.deleteBuffers(2, &m_buffer);
 			m_buffer = 0;


### PR DESCRIPTION
On GLES 2.0 only drivers, the egl_fence_persistent_buffer test fails to create its GLES 3.1 context and an exception is thrown at chooseSingleConfig, which aborts its init early.
The initialization doesn't reach initGLFunctions and GL function pointers are left uninitialized, which causes a segfault and crash in the deinit path.
Fix the deinit path so that it doesn't crash but just reports "No matching EGL config found" like other EGL tests with those drivers.

Affects:
  dEQP-EGL.functional.fence_sync.valid.egl_fence_persistent_buffer

This has been crashing on two GLES 2.0 drivers on mesa since this CTS update https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/24947 .