### PR TITLE
Update vktApiFeatureInfo.cpp

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
@@ -1,4 +1,4 @@
-/*-------------------------------------------------------------------------
+eeeeeeeeee/*-------------------------------------------------------------------------
  * Vulkan Conformance Tests
  * ------------------------
  *
@@ -1367,7 +1367,7 @@ tcu::TestStatus validateLimitsExtVertexAttributeDivisor (Context& context)
 #ifndef CTS_USES_VULKANSC
 	const InstanceInterface&									vki									= context.getInstanceInterface();
 	const VkPhysicalDevice										physicalDevice						= context.getPhysicalDevice();
-	vk::VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT		vertexAttributeDivisorProperties	= vk::initVulkanStructure();
+	vk::VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR		vertexAttributeDivisorProperties	= vk::initVulkanStructure();
 	vk::VkPhysicalDeviceProperties2								properties2							= vk::initVulkanStructure(&vertexAttributeDivisorProperties);
 	vki.getPhysicalDeviceProperties2(physicalDevice, &properties2);
 #else


### PR DESCRIPTION
The usage of VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT causes the Limit validation failed vertexAttributeDivisorProperties.maxVertexAttribDivisor test case to fail with the following error: "reported value is 0 expected MIN 65535"