### PR TITLE
Add tests for EXT_texture_format_BGRA8888

### DIFF
--- a/framework/opengl/gluStrUtil.inl
+++ b/framework/opengl/gluStrUtil.inl
@@ -888,6 +888,7 @@ const char* getUncompressedTextureFormatName (int value)
 		case GL_SR8_EXT:			return "GL_SR8_EXT";
 		case GL_SRG8_EXT:			return "GL_SRG8_EXT";
 		case GL_BGRA:				return "GL_BGRA";
+		case GL_BGRA8_EXT:			return "GL_BGRA8_EXT";
 		default:					return DE_NULL;
 	}
 }
@@ -1738,6 +1739,7 @@ const char* getTextureFormatName (int value)
 		case GL_SR8_EXT:									return "GL_SR8_EXT";
 		case GL_SRG8_EXT:									return "GL_SRG8_EXT";
 		case GL_BGRA:										return "GL_BGRA";
+		case GL_BGRA8_EXT:									return "GL_BGRA8_EXT";
 		case GL_COMPRESSED_R11_EAC:							return "GL_COMPRESSED_R11_EAC";
 		case GL_COMPRESSED_SIGNED_R11_EAC:					return "GL_COMPRESSED_SIGNED_R11_EAC";
 		case GL_COMPRESSED_RG11_EAC:						return "GL_COMPRESSED_RG11_EAC";

--- a/framework/opengl/gluTextureUtil.cpp
+++ b/framework/opengl/gluTextureUtil.cpp
@@ -543,6 +543,9 @@ tcu::TextureFormat mapGLInternalFormat (deUint32 internalFormat)
 		case GL_R8_SNORM:			return TextureFormat(TextureFormat::R,		TextureFormat::SNORM_INT8);
 		case GL_SR8_EXT:			return TextureFormat(TextureFormat::sR,		TextureFormat::UNORM_INT8);
 
+		case GL_BGRA:				return TextureFormat(TextureFormat::BGRA,	TextureFormat::UNORM_INT8);
+		case GL_BGRA8_EXT:			return TextureFormat(TextureFormat::BGRA,	TextureFormat::UNORM_INT8);
+
 		case GL_DEPTH_COMPONENT32F:	return TextureFormat(TextureFormat::D,		TextureFormat::FLOAT);
 		case GL_DEPTH_COMPONENT24:	return TextureFormat(TextureFormat::D,		TextureFormat::UNSIGNED_INT_24_8);
 		case GL_DEPTH_COMPONENT32:	return TextureFormat(TextureFormat::D,		TextureFormat::UNSIGNED_INT32);

--- a/framework/opengl/simplereference/sglrReferenceContext.cpp
+++ b/framework/opengl/simplereference/sglrReferenceContext.cpp
@@ -289,6 +289,7 @@ ReferenceContextLimits::ReferenceContextLimits (const glu::RenderContext& render
 	// \todo [2013-08-01 pyry] Do we want to make these conditional based on renderCtx?
 	addExtension("GL_EXT_color_buffer_half_float");
 	addExtension("GL_EXT_color_buffer_float");
+	addExtension("GL_EXT_texture_format_BGRA8888");
 
 	if (contextSupports(contextType, glu::ApiType::es(3,1)))
 		addExtension("GL_EXT_texture_cube_map_array");
@@ -2284,6 +2285,7 @@ deUint32 ReferenceContext::checkFramebufferStatus (deUint32 target)
 			case TextureFormat::RGBA:
 			case TextureFormat::sRGB:
 			case TextureFormat::sRGBA:
+			case TextureFormat::BGRA:
 				if (point != Framebuffer::ATTACHMENTPOINT_COLOR0)
 					attachmentComplete = false;
 				break;

--- a/modules/gles2/functional/es2fFboRenderTest.cpp
+++ b/modules/gles2/functional/es2fFboRenderTest.cpp
@@ -267,6 +267,7 @@ const char* FboConfig::getFormatName (GLenum format)
 	{
 		case GL_RGB:				return "rgb";
 		case GL_RGBA:				return "rgba";
+		case GL_BGRA:				return "bgra";
 		case GL_ALPHA:				return "alpha";
 		case GL_LUMINANCE:			return "luminance";
 		case GL_LUMINANCE_ALPHA:	return "luminance_alpha";
@@ -400,6 +401,12 @@ static void checkColorFormatSupport (sglr::Context& context, deUint32 sizedForma
 		case GL_R16F:
 			if (!isExtensionSupported(context, "GL_EXT_color_buffer_half_float"))
 				throw tcu::NotSupportedError("GL_EXT_color_buffer_half_float is not supported");
+			break;
+
+		case GL_BGRA:
+			if (!isExtensionSupported(context, "GL_EXT_texture_format_BGRA8888"))
+				throw tcu::NotSupportedError("GL_EXT_texture_format_BGRA8888 is not supported");
+			break;
 
 		default:
 			break;
@@ -2112,6 +2119,7 @@ void addChildVariants (deqp::gles2::TestCaseGroup* group)
 		{ GL_RENDERBUFFER,	GL_RGBA4 },
 //		{ GL_RENDERBUFFER,	GL_RGBA16F },
 //		{ GL_RENDERBUFFER,	GL_RGB16F }
+		{ GL_RENDERBUFFER,	GL_BGRA },
 	};
 	TypeFormatPair depthbufferConfigs[] =
 	{

--- a/modules/gles2/functional/es2fFboRenderTest.cpp
+++ b/modules/gles2/functional/es2fFboRenderTest.cpp
@@ -404,6 +404,7 @@ static void checkColorFormatSupport (sglr::Context& context, deUint32 sizedForma
 			break;
 
 		case GL_BGRA:
+		case GL_BGRA8_EXT:
 			if (!isExtensionSupported(context, "GL_EXT_texture_format_BGRA8888"))
 				throw tcu::NotSupportedError("GL_EXT_texture_format_BGRA8888 is not supported");
 			break;
@@ -2114,6 +2115,7 @@ void addChildVariants (deqp::gles2::TestCaseGroup* group)
 //		{ GL_TEXTURE_2D,	GL_LUMINANCE_ALPHA },
 		{ GL_TEXTURE_2D,	GL_RGB },
 		{ GL_TEXTURE_2D,	GL_RGBA },
+		{ GL_TEXTURE_2D,	GL_BGRA },
 		{ GL_RENDERBUFFER,	GL_RGB565 },
 		{ GL_RENDERBUFFER,	GL_RGB5_A1 },
 		{ GL_RENDERBUFFER,	GL_RGBA4 },

--- a/modules/gles3/functional/es3fTextureFilteringTests.cpp
+++ b/modules/gles3/functional/es3fTextureFilteringTests.cpp
@@ -77,7 +77,8 @@ void checkSupport (const glu::ContextInfo& info, deUint32 internalFormat)
 	if (internalFormat == GL_SRG8_EXT && !info.isExtensionSupported("GL_EXT_texture_sRGB_RG8"))
 		TCU_THROW(NotSupportedError, "GL_EXT_texture_sRGB_RG8 is not supported.");
 
-	if (internalFormat == GL_BGRA && !info.isExtensionSupported("GL_EXT_texture_format_BGRA8888"))
+	if ((internalFormat == GL_BGRA || internalFormat == GL_BGRA8_EXT) &&
+		!info.isExtensionSupported("GL_EXT_texture_format_BGRA8888"))
 		TCU_THROW(NotSupportedError, "GL_EXT_texture_format_BGRA8888 is not supported.");
 }
 
@@ -1308,6 +1309,7 @@ void TextureFilteringTests::init (void)
 		{ "srgb_rg8",		GL_SRG8_EXT			},
 		{ "rgb10_a2",		GL_RGB10_A2			},
 		{ "bgra",			GL_BGRA				},
+		{ "bgra8",			GL_BGRA8_EXT		}
 	};
 
 	// 2D texture filtering.

--- a/modules/gles3/functional/es3fTextureFilteringTests.cpp
+++ b/modules/gles3/functional/es3fTextureFilteringTests.cpp
@@ -76,6 +76,9 @@ void checkSupport (const glu::ContextInfo& info, deUint32 internalFormat)
 
 	if (internalFormat == GL_SRG8_EXT && !info.isExtensionSupported("GL_EXT_texture_sRGB_RG8"))
 		TCU_THROW(NotSupportedError, "GL_EXT_texture_sRGB_RG8 is not supported.");
+
+	if (internalFormat == GL_BGRA && !info.isExtensionSupported("GL_EXT_texture_format_BGRA8888"))
+		TCU_THROW(NotSupportedError, "GL_EXT_texture_format_BGRA8888 is not supported.");
 }
 
 } // anonymous
@@ -1303,7 +1306,8 @@ void TextureFilteringTests::init (void)
 		{ "srgb8_alpha8",	GL_SRGB8_ALPHA8		},
 		{ "srgb_r8",		GL_SR8_EXT			},
 		{ "srgb_rg8",		GL_SRG8_EXT			},
-		{ "rgb10_a2",		GL_RGB10_A2			}
+		{ "rgb10_a2",		GL_RGB10_A2			},
+		{ "bgra",			GL_BGRA				},
 	};
 
 	// 2D texture filtering.

--- a/modules/glshared/glsFboCompletenessTests.cpp
+++ b/modules/glshared/glsFboCompletenessTests.cpp
@@ -218,6 +218,7 @@ static const FormatKey s_qcomRenderSRGBR8RG8Formats[] =
 static const FormatKey s_extTextureFormatBGRA8888Formats[] =
 {
 	GL_BGRA,
+	GL_BGRA8_EXT,
 };
 
 static const FormatExtEntry s_esExtFormats[] =

--- a/modules/glshared/glsFboCompletenessTests.cpp
+++ b/modules/glshared/glsFboCompletenessTests.cpp
@@ -215,6 +215,11 @@ static const FormatKey s_qcomRenderSRGBR8RG8Formats[] =
 	GL_SRG8_EXT,
 };
 
+static const FormatKey s_extTextureFormatBGRA8888Formats[] =
+{
+	GL_BGRA,
+};
+
 static const FormatExtEntry s_esExtFormats[] =
 {
 	{
@@ -401,6 +406,12 @@ static const FormatExtEntry s_esExtFormats[] =
 		(deUint32)(REQUIRED_RENDERABLE | COLOR_RENDERABLE | RENDERBUFFER_VALID | TEXTURE_VALID),
 		GLS_ARRAY_RANGE(s_qcomRenderSRGBR8RG8Formats)
 	},
+
+	{
+		"GL_EXT_texture_format_BGRA8888",
+		(deUint32)(REQUIRED_RENDERABLE | COLOR_RENDERABLE | RENDERBUFFER_VALID | TEXTURE_VALID),
+		GLS_ARRAY_RANGE(s_extTextureFormatBGRA8888Formats)
+	}
 };
 
 Context::Context (TestContext& testCtx,


### PR DESCRIPTION
This adds tests for EXT_texture_format_BGRA8888, including the recent changes (see https://github.com/KhronosGroup/OpenGL-Registry/pull/603)