### PR TITLE
Add missing cmath includes

### DIFF
--- a/external/openglcts/modules/common/glcFramebufferBlitTests.cpp
+++ b/external/openglcts/modules/common/glcFramebufferBlitTests.cpp
@@ -41,6 +41,8 @@
 #include "tcuRenderTarget.hpp"
 #include "tcuStringTemplate.hpp"
 
+#include <cmath>
+
 #define CHECK(actual, expected, info)                                                                          \
     {                                                                                                          \
         result &= ((actual) != (expected)) ? false : true;                                                     \

--- a/external/openglcts/modules/common/glcTextureLodBiasTests.cpp
+++ b/external/openglcts/modules/common/glcTextureLodBiasTests.cpp
@@ -39,6 +39,8 @@
 #include "tcuTestLog.hpp"
 #include "tcuStringTemplate.hpp"
 
+#include <cmath>
+
 using namespace glw;
 using namespace glu;
 


### PR DESCRIPTION
These files use std::fabs() but didn't include <cmath>. This used to work due to transitive includes. But a recent libc++ removes enough transitive includes that cmath now needs an explicit include.

No behavior change.