### PR TITLE
QueryPoolComputeStatsTest: Check if query is supported in compute queue

### DIFF
--- a/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
+++ b/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
@@ -163,11 +163,6 @@ uint32_t findNonGraphicsQueueFamilyIndex(const InstanceInterface &vki, const VkP
     return qfIndex;
 }
 
-void checkSupportForNonGraphicsQueueFamily(const InstanceInterface &vki, const VkPhysicalDevice physicalDevice)
-{
-    findNonGraphicsQueueFamilyIndex(vki, physicalDevice);
-}
-
 // Device helper: this is needed in some tests when we create custom devices.
 class DeviceHelper
 {
@@ -3853,8 +3848,13 @@ public:
         {
             const auto &vki           = context.getInstanceInterface();
             const auto physicalDevice = context.getPhysicalDevice();
-
-            checkSupportForNonGraphicsQueueFamily(vki, physicalDevice);
+            uint32_t computeQueueFamilyIdx = findNonGraphicsQueueFamilyIndex(vki, physicalDevice);
+            uint32_t counterCount;
+            VkResult result;
+			
+            result = vki.enumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, computeQueueFamilyIdx, &counterCount, NULL, NULL);
+            if (result != VK_SUCCESS || counterCount == 0)
+            	TCU_THROW(NotSupportedError, "Query not supported in compute queue");
         }
     }
 


### PR DESCRIPTION
Some drivers may not support queries in compute queue. This should turn some failures in
dEQP-VK.query_pool.statistics_query.reset_after_copy.compute_shader_invocations.* to not supported.