### PR TITLE
video encode: Fix tests for implementations with detection of insufficient bitstream buffer range

### DIFF
--- a/external/vulkancts/modules/vulkan/video/vktVideoCapabilitiesTests.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoCapabilitiesTests.cpp
@@ -540,7 +540,8 @@ void VideoCapabilitiesQueryTestInstance::validateVideoEncodeCapabilities(
     VALIDATE_FIELD_EQUAL(videoEncodeCapabilitiesKHR, videoEncodeCapabilitiesKHRSecond, supportedEncodeFeedbackFlags);
 
     const VkVideoEncodeCapabilityFlagsKHR videoEncodeCapabilityFlags =
-        VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR;
+        VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR |
+        VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR;
 
     if ((videoEncodeCapabilitiesKHR.flags & ~videoEncodeCapabilityFlags) != 0)
         TCU_FAIL("Undeclared VkVideoEncodeCapabilitiesKHR.flags returned");

--- a/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
@@ -2258,9 +2258,10 @@ tcu::TestStatus VideoEncodeTestInstance::iterate(void)
                 pNext = videoEncodePictureInfoPtr;
             }
 
-            videoEncodeFrameInfos.push_back(getVideoEncodeInfo(
-                pNext, *encodeBuffer, dstBufferOffset, (*imagePictureResourceVector[srcPictureResourceIdx]),
-                setupReferenceSlotPtr, refsCount, (refsPool == 0) ? nullptr : referenceSlots));
+            videoEncodeFrameInfos.push_back(
+                getVideoEncodeInfo(pNext, *encodeBuffer, dstBufferOffset, encodeBufferSize - dstBufferOffset,
+                                   (*imagePictureResourceVector[srcPictureResourceIdx]), setupReferenceSlotPtr,
+                                   refsCount, (refsPool == 0) ? nullptr : referenceSlots));
 
             if (!useInlineQueries)
                 videoDeviceDriver.cmdBeginQuery(encodeCmdBuffer, encodeQueryPool.get(), 1, 0);

--- a/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.cpp
@@ -1967,6 +1967,7 @@ de::MovePtr<StdVideoH264PictureParameterSet> getStdVideoH264DecodePictureParamet
 
 de::MovePtr<VkVideoEncodeInfoKHR> getVideoEncodeInfo(const void *pNext, const VkBuffer &dstBuffer,
                                                      const VkDeviceSize &dstBufferOffset,
+                                                     const VkDeviceSize &dstBufferRange,
                                                      const VkVideoPictureResourceInfoKHR &srcPictureResource,
                                                      const VkVideoReferenceSlotInfoKHR *pSetupReferenceSlot,
                                                      const uint32_t &referenceSlotCount,
@@ -1978,7 +1979,7 @@ de::MovePtr<VkVideoEncodeInfoKHR> getVideoEncodeInfo(const void *pNext, const Vk
         static_cast<VkVideoEncodeFlagsKHR>(0),   //  VkVideoEncodeFlagsKHR flags;
         dstBuffer,                               //  VkBuffer dstBuffer;
         dstBufferOffset,                         //  VkDeviceSize dstBufferOffset;
-        0u,                                      //  VkDeviceSize dstBufferRange;
+        dstBufferRange,                          //  VkDeviceSize dstBufferRange;
         srcPictureResource,                      //  VkVideoPictureResourceInfoKHR srcPictureResource;
         pSetupReferenceSlot,                     //  const VkVideoReferenceSlotInfoKHR* pSetupReferenceSlot;
         referenceSlotCount,                      //  uint32_t referenceSlotCount;

--- a/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.hpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.hpp
@@ -337,6 +337,7 @@ de::MovePtr<VkVideoCodingControlInfoKHR> getVideoCodingControlInfo(VkVideoCoding
 
 de::MovePtr<VkVideoEncodeInfoKHR> getVideoEncodeInfo(const void *pNext, const VkBuffer &dstBuffer,
                                                      const VkDeviceSize &dstBufferOffset,
+                                                     const VkDeviceSize &dstBufferRange,
                                                      const VkVideoPictureResourceInfoKHR &srcPictureResource,
                                                      const VkVideoReferenceSlotInfoKHR *pSetupReferenceSlot,
                                                      const uint32_t &referenceSlotCount,


### PR DESCRIPTION
This change allows implementation to report `VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR` without causing a failed test dEQP-VK.video.capabilities.*_encode_capabilities_query.

Further this change sets `dstBufferRange` in `VkVideoEncodeInfoKHR` to valid values (instead of 0) so that implementations supporting insufficient bitstream buffer range detection do not report an error on video encode.
