### PR TITLE
video encode: Fix validation error for empty video session memory requirements

### DIFF
--- a/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoTestUtils.cpp
@@ -626,6 +626,9 @@ vector<AllocationPtr> getAndBindVideoSessionMemory(const DeviceInterface &vkd, c
     vector<AllocationPtr> allocations(videoSessionMemoryRequirements.size());
     vector<VkBindVideoSessionMemoryInfoKHR> videoBindsMemoryKHR(videoSessionMemoryRequirements.size());
 
+    if (allocations.empty())
+        return allocations;
+    
     for (size_t ndx = 0; ndx < allocations.size(); ++ndx)
     {
         const VkMemoryRequirements &requirements = videoSessionMemoryRequirements[ndx].memoryRequirements;


### PR DESCRIPTION
If the implementation does not request video session memory, binding must not be called. This caused a validation layer error: VUID-vkBindVideoSessionMemoryKHR-bindSessionMemoryInfoCount-arraylength

Affects:
dEQP-VK.video.encode.*