### PR TITLE
video encode: support more DPB image formats and usage limitations

### DIFF
--- a/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
@@ -1691,7 +1691,7 @@ tcu::TestStatus VideoEncodeTestInstance::iterate(void)
             videoDeviceDriver, videoDevice, videoEncodeSessionParametersCreateInfos.back().get()));
     }
 
-    const VkImageUsageFlags dpbImageUsage = VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    const VkImageUsageFlags dpbImageUsage = VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR;
     // If the implementation does not support individual images for DPB and so must use arrays
     const bool separateReferenceImages =
         videoCapabilities.get()->flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR;

--- a/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
+++ b/external/vulkancts/modules/vulkan/video/vktVideoEncodeTests.cpp
@@ -1325,6 +1325,7 @@ protected:
 
     VkFormat checkImageFormat(VkImageUsageFlags flags, const VkVideoProfileListInfoKHR *videoProfileList,
                               const VkFormat requiredFormat);
+    VkFormat getFirstSupportedImageFormat(VkImageUsageFlags flags, const VkVideoProfileListInfoKHR *videoProfileList);
 
     bool checkQueryResultSupport(void);
 
@@ -1386,6 +1387,19 @@ VkFormat VideoEncodeTestInstance::checkImageFormat(VkImageUsageFlags flags,
             return requiredFormat;
 
     TCU_THROW(NotSupportedError, "Failed to find required picture format");
+}
+
+VkFormat VideoEncodeTestInstance::getFirstSupportedImageFormat(VkImageUsageFlags flags,
+                                                               const VkVideoProfileListInfoKHR *videoProfileList)
+{
+    const InstanceInterface &vki               = m_context.getInstanceInterface();
+    const VkPhysicalDevice physicalDevice      = m_context.getPhysicalDevice();
+    MovePtr<vector<VkFormat>> supportedFormats = getSupportedFormats(vki, physicalDevice, flags, videoProfileList);
+
+    if (!supportedFormats || supportedFormats->empty())
+        TCU_THROW(NotSupportedError, "No supported picture formats");
+
+    return supportedFormats->front();
 }
 
 bool VideoEncodeTestInstance::checkQueryResultSupport(void)
@@ -1500,8 +1514,8 @@ tcu::TestStatus VideoEncodeTestInstance::iterate(void)
 
     const VkFormat imageFormat = checkImageFormat(VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR, videoEncodeProfileList.get(),
                                                   VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
-    const VkFormat dpbImageFormat = checkImageFormat(VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR,
-                                                     videoEncodeProfileList.get(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+    const VkFormat dpbImageFormat =
+        getFirstSupportedImageFormat(VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR, videoEncodeProfileList.get());
 
     const VideoDevice::VideoDeviceFlags videoDeviceFlags = m_testDefinition->requiredDeviceFlags();
 
@@ -1696,7 +1710,7 @@ tcu::TestStatus VideoEncodeTestInstance::iterate(void)
     const bool separateReferenceImages =
         videoCapabilities.get()->flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR;
     const VkImageCreateInfo dpbImageCreateInfo =
-        makeImageCreateInfo(imageFormat, codedExtent, 0, &encodeQueueFamilyIndex, dpbImageUsage,
+        makeImageCreateInfo(dpbImageFormat, codedExtent, 0, &encodeQueueFamilyIndex, dpbImageUsage,
                             videoEncodeProfileList.get(), separateReferenceImages ? 1 : dpbSlots);
     const VkImageViewType dpbImageViewType =
         separateReferenceImages ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -1753,7 +1767,7 @@ tcu::TestStatus VideoEncodeTestInstance::iterate(void)
 
         std::unique_ptr<Move<VkImageView>> dpbImageView(new Move<VkImageView>(
             makeImageView(videoDeviceDriver, videoDevice, dpbImages[separateReferenceImages ? j : 0]->get(),
-                          dpbImageViewType, imageFormat, dpbImageSubresourceRange)));
+                          dpbImageViewType, dpbImageFormat, dpbImageSubresourceRange)));
         std::unique_ptr<VkVideoPictureResourceInfoKHR> dpbPictureResource(
             new VkVideoPictureResourceInfoKHR(makeVideoPictureResource(codedExtent, 0, dpbImageView->get())));
 


### PR DESCRIPTION
This allows to use all image formats for DPB images. The video encode tests are not accessing the images, so they can support any image format.
Further, as the test cases do not access the images, only the usage flag `VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR` is necessary. I am not aware that implementations must support `VK_IMAGE_USAGE_TRANSFER_SRC_BIT`, but maybe I am wrong here?

Affects:
dEQP-VK.video.encode.*