### PR TITLE
Consider GL_EXT_read_format_bgra extension for glReadPixels

### DIFF
--- a/framework/opengl/gluTextureUtil.cpp
+++ b/framework/opengl/gluTextureUtil.cpp
@@ -319,6 +319,9 @@ uint32_t getInternalFormat(tcu::TextureFormat texFormat)
     case FMT_CASE(sRG, UNORM_INT8):
         return GL_SRG8_EXT;
 
+    case FMT_CASE(BGRA, UNORM_INT8):
+        return GL_BGRA8_EXT;
+
     case FMT_CASE(R, FLOAT):
         return GL_R32F;
     case FMT_CASE(R, SIGNED_INT32):


### PR DESCRIPTION
If the driver supports GL_EXT_read_format_bgra extension, we should use it to select exact pair for glReadPixels.

Affects: KHR-GLES3*.core.nearest_edge.offset_*