### PR TITLE
Atomic barrier sum check

### DIFF
--- a/external/vulkancts/data/vulkan/amber/compute/atomic_barrier_sum_small.amber
+++ b/external/vulkancts/data/vulkan/amber/compute/atomic_barrier_sum_small.amber
@@ -1,0 +1,58 @@
+#!amber
+# Copyright 2024 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The purpose of this test is to check the behavior of workgroup atomics in
+# combination with barriers.
+# This is known to cause issues on the mobile devices given the CTS failures
+# for webgpu
+# See: crbug.com/42241359
+
+SHADER compute workgroup_shared_atomic_shader GLSL
+#version 430
+
+layout(local_size_x = 3, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) buffer block1 {
+  uint ssbo_write[];
+};
+
+shared uint wg_shared;
+
+void main() {
+    if( gl_LocalInvocationID.x == 0){
+      atomicExchange(wg_shared, 7);
+    }
+
+    barrier();
+    atomicAdd(wg_shared,1);
+    barrier();
+
+    if(gl_LocalInvocationID.x == 0) {
+      ssbo_write[0] = atomicExchange(wg_shared,0);
+    }
+}
+END
+
+BUFFER buf_uint DATA_TYPE uint32 SIZE 16 FILL 123
+
+PIPELINE compute pipeline
+  ATTACH workgroup_shared_atomic_shader
+  BIND BUFFER buf_uint AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf_uint IDX 0 EQ  10

--- a/external/vulkancts/modules/vulkan/compute/vktComputeBasicComputeShaderTests.cpp
+++ b/external/vulkancts/modules/vulkan/compute/vktComputeBasicComputeShaderTests.cpp
@@ -5308,6 +5308,8 @@ tcu::TestCaseGroup *createBasicComputeShaderTests(tcu::TestContext &testCtx,
         basicComputeTests->addChild(
             cts_amber::createAmberTestCase(testCtx, "write_ssbo_array", "", "compute", "write_ssbo_array.amber"));
         basicComputeTests->addChild(
+            cts_amber::createAmberTestCase(testCtx, "atomic_barrier_sum_small", "", "compute", "atomic_barrier_sum_small.amber"));
+        basicComputeTests->addChild(
             cts_amber::createAmberTestCase(testCtx, "branch_past_barrier", "", "compute", "branch_past_barrier.amber"));
         basicComputeTests->addChild(cts_amber::createAmberTestCase(
             testCtx, "webgl_spirv_loop",

--- a/external/vulkancts/mustpass/main/vk-default/compute.txt
+++ b/external/vulkancts/mustpass/main/vk-default/compute.txt
@@ -1,3 +1,4 @@
+dEQP-VK.compute.pipeline.basic.atomic_barrier_sum_small
 dEQP-VK.compute.pipeline.basic.branch_past_barrier
 dEQP-VK.compute.pipeline.basic.concurrent_compute
 dEQP-VK.compute.pipeline.basic.copy_image_to_ssbo_large


### PR DESCRIPTION
Atomic barrier sum check. Some compliers do not seem to respect the synchronization requirements of the barrier for workgroups sizes on the order of a subgroup.

crbug.com/42241359