### PR TITLE
Fix loading absolute path libs with LD_LIBRARY_PATH

### DIFF
--- a/framework/delibs/deutil/deDynamicLibrary.c
+++ b/framework/delibs/deutil/deDynamicLibrary.c
@@ -29,8 +29,6 @@
 /* Posix implementation. */
 
 #include <dlfcn.h>
-#include <libgen.h>
-#include <stdlib.h>
 
 struct deDynamicLibrary_s
 {
@@ -43,18 +41,7 @@ deDynamicLibrary *deDynamicLibrary_open(const char *fileName)
     if (!library)
         return NULL;
 
-    if (getenv("LD_LIBRARY_PATH"))
-    {
-        // basename() requires a non-const string because it may modify the its contents, so we cannot pass fileName to
-        // it directly. The string may be coming from statically allocated memory. E.g. this segfaulted in FreeBSD.
-        char *aux = deStrdup(fileName);
-        if (!aux)
-            return NULL;
-        library->libHandle = dlopen(basename(aux), RTLD_LAZY);
-        deFree(aux);
-    }
-    else
-        library->libHandle = dlopen(fileName, RTLD_LAZY);
+    library->libHandle = dlopen(fileName, RTLD_LAZY);
 
     if (!library->libHandle)
     {


### PR DESCRIPTION
Commit 5aa5b0809f055f36fc384644925c384596b2f7cd changed the way libraries are dynamically loaded when `LD_LIBRARY_PATH` is set to only take the filename into account and not the complete path. This seems to be overlooked code meant for testing as the commit is about video testing and not library loading.

Revert the file to its previous state to fix loading libraries that are specified with absolute paths.

Fixes GitHub issue #479.