### PR TITLE
Add missing cmath includes

### DIFF
--- a/external/openglcts/modules/common/glcTextureStorageTests.cpp
+++ b/external/openglcts/modules/common/glcTextureStorageTests.cpp
@@ -38,6 +38,8 @@
 #include "tcuRenderTarget.hpp"
 #include "tcuTestLog.hpp"
 
+#include <cmath>
+
 using namespace glw;
 using namespace glu;
 


### PR DESCRIPTION
This fixes the compilation errors in chromium and ANGLE:

glcTextureStorageTests.cpp:76:35: error: no member named 'floor' in namespace 'std'
glcTextureStorageTests.cpp:76:46: error: no member named 'log2f' in namespace 'std'