### PR TITLE
Fix instances of -Wmissing-template-arg-list-after-template-kw

### DIFF
--- a/external/vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp
+++ b/external/vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp
@@ -1081,15 +1081,15 @@ struct IntervalWriter
 
         else if (interval.lo() == interval.hi())
         {
-            const auto lo = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.lo()));
+            const auto lo = FloatTypeSelector<GenType>::type::convert(tcu::Float64(interval.lo()));
             os << '{';
             void(lo.isDenorm() ? (os << std::hexfloat << interval.lo() << std::defaultfloat) : (os << interval.lo()));
             os << '}';
         }
         else
         {
-            const auto lo = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.lo()));
-            const auto hi = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.hi()));
+            const auto lo = FloatTypeSelector<GenType>::type::convert(tcu::Float64(interval.lo()));
+            const auto hi = FloatTypeSelector<GenType>::type::convert(tcu::Float64(interval.hi()));
 
             os << '[';
             void(lo.isDenorm() ? (os << std::hexfloat << interval.lo() << std::defaultfloat) : (os << interval.lo()));
@@ -7048,7 +7048,7 @@ void DefaultSubnormalsSampling<T>::genSubnormals(const FloatFormat &fmt, const P
             DE_ASSERT((man & fullMantissaMask) != 0);
             DE_UNREF(fullMantissaMask);
 
-            outValues.push_back(SamplingT::SelectorT::template conv(val));
+            outValues.push_back(SamplingT::SelectorT::conv(val));
         }
     }
 }


### PR DESCRIPTION
Clang has a new warning that requires a template argument list after using the template keyword. Remove uses of the template keyword when we're not specifying types.

See https://github.com/llvm/llvm-project/issues/94194 for the upstream clang change.

With `-Werror`, this warning causes the build to fail:
```
.../vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp:1084:72: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1084 |             const auto lo = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.lo()));
      |                                                                        ^
.../vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp:1091:72: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1091 |             const auto lo = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.lo()));
      |                                                                        ^
.../vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp:1092:72: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1092 |             const auto hi = FloatTypeSelector<GenType>::type::template convert(tcu::Float64(interval.hi()));
      |                                                                        ^
.../vulkancts/modules/vulkan/shaderexecutor/vktShaderBuiltinPrecisionTests.cpp:7051:64: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 7051 |             outValues.push_back(SamplingT::SelectorT::template conv(val));
      |                                                                ^
4 errors generated.
```