### PR TITLE
explictily set the inner tess level to 1 to avoid some random corrupt…

### DIFF
--- a/external/vulkancts/modules/vulkan/tessellation/vktTessellationMiscDrawTests.cpp
+++ b/external/vulkancts/modules/vulkan/tessellation/vktTessellationMiscDrawTests.cpp
@@ -1298,6 +1298,8 @@ void TessInstancedDrawTestCase::initPrograms(vk::SourceCollections &programColle
               << "{\n"
               << "    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;\n"
               << "    \n"
+              << "    gl_TessLevelInner[0] = 1.0f;\n"
+              << "    gl_TessLevelInner[1] = 1.0f;\n"
               << "    gl_TessLevelOuter[0] = 1.0f;\n"
               << "    gl_TessLevelOuter[1] = 1.0f;\n"
               << "    gl_TessLevelOuter[2] = 1.0f;\n"


### PR DESCRIPTION
…ion on some drivers