### PR TITLE
Fix non-zero offset added to nullptr

### DIFF
--- a/framework/common/tcuTextureUtil.cpp
+++ b/framework/common/tcuTextureUtil.cpp
@@ -1557,12 +1557,12 @@ uint32_t packRGB999E5(const tcu::Vec4 &color)
 
 static const void *addOffset(const void *ptr, int numBytes)
 {
-    return (const uint8_t *)ptr + numBytes;
+    return (ptr) ? (const uint8_t *)ptr + numBytes : reinterpret_cast<uint8_t*>(numBytes);
 }
 
 static void *addOffset(void *ptr, int numBytes)
 {
-    return (uint8_t *)ptr + numBytes;
+    return (ptr) ? (uint8_t *)ptr + numBytes : reinterpret_cast<uint8_t*>(numBytes);
 }
 
 template <typename AccessType>

--- a/modules/glshared/glsDrawTest.cpp
+++ b/modules/glshared/glsDrawTest.cpp
@@ -1488,14 +1488,14 @@ void AttributeArray::bindAttribute(uint32_t loc)
 
                 // Output type is float type
                 m_ctx.vertexAttribPointer(loc, size, inputTypeToGL(m_inputType), m_normalize, m_stride,
-                                          basePtr + m_offset);
+                                          (basePtr) ? basePtr + m_offset : reinterpret_cast<uint8_t*>(m_offset));
                 GLU_EXPECT_NO_ERROR(m_ctx.getError(), "glVertexAttribPointer()");
             }
             else
             {
                 // Output type is int type
                 m_ctx.vertexAttribIPointer(loc, m_componentCount, inputTypeToGL(m_inputType), m_stride,
-                                           basePtr + m_offset);
+                                           (basePtr) ? basePtr + m_offset : reinterpret_cast<uint8_t*>(m_offset));
                 GLU_EXPECT_NO_ERROR(m_ctx.getError(), "glVertexAttribIPointer()");
             }
         }
@@ -1507,7 +1507,7 @@ void AttributeArray::bindAttribute(uint32_t loc)
             DE_ASSERT(outputTypeIsFloatType(m_outputType));
 
             m_ctx.vertexAttribPointer(loc, m_componentCount, inputTypeToGL(m_inputType), m_normalize, m_stride,
-                                      basePtr + m_offset);
+                                      (basePtr) ? basePtr + m_offset : reinterpret_cast<uint8_t*>(m_offset));
             GLU_EXPECT_NO_ERROR(m_ctx.getError(), "glVertexAttribPointer()");
         }
 
@@ -3786,7 +3786,8 @@ DrawTest::IterateResult DrawTest::iterate(void)
                     seed, (int)elementCount, spec.indexType, spec.indexPointerOffset, indexMin, indexMax, indexBase);
                 const char *indexPointerBase =
                     (spec.indexStorage == DrawTestSpec::STORAGE_USER) ? (indexArray) : (nullptr);
-                const char *indexPointer = indexPointerBase + spec.indexPointerOffset;
+                const char *indexPointer = (indexPointerBase) ? indexPointerBase + spec.indexPointerOffset :
+                                                                reinterpret_cast<char*>(spec.indexPointerOffset);
 
                 de::UniquePtr<AttributeArray> glArray(new AttributeArray(spec.indexStorage, *m_glesContext));
                 de::UniquePtr<AttributeArray> rrArray(new AttributeArray(spec.indexStorage, *m_refContext));


### PR DESCRIPTION
This change fixes some cases in the code where a non-zero offset is added to a potential nullptr value, which can lead to undefined behavior errors.