### PR TITLE
Fix undefined behabior in various tests

### DIFF
--- a/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
+++ b/external/vulkancts/modules/vulkan/query_pool/vktQueryPoolStatisticsTests.cpp
@@ -4197,7 +4197,7 @@ public:
                        << "layout(location = 0) out vec4 out_color;\n"
                        << "\n"
                        << "void main() {\n"
-                       << "    gl_Position = positions[gl_VertexIndex];\n"
+                       << "    gl_Position = positions[gl_VertexIndex % 4];\n"
                        << "    gl_PointSize = 1.0f;\n"
                        << "    out_color = vec4(0.0f, 0.0f, 1.0f, 1.0f); // blue\n"
                        << "}\n";

--- a/external/vulkancts/modules/vulkan/tessellation/vktTessellationGeometryPassthroughTests.cpp
+++ b/external/vulkancts/modules/vulkan/tessellation/vktTessellationGeometryPassthroughTests.cpp
@@ -168,7 +168,7 @@ void IdentityGeometryShaderTestCase::initPrograms(vk::SourceCollections &program
         std::ostringstream src;
         src << glu::getGLSLVersionDeclaration(glu::GLSL_VERSION_310_ES) << "\n"
             << "#extension GL_EXT_tessellation_shader : require\n"
-            << "layout(vertices = 4) out;\n"
+            << "layout(vertices = " << (m_primitiveType == TESSPRIMITIVETYPE_TRIANGLES ? 3 : 4) << ") out;\n"
             << "\n"
             << "layout(set = 0, binding = 0, std430) readonly restrict buffer TessLevels {\n"
             << "    float inner0;\n"


### PR DESCRIPTION
Currently many dEQP tests rely on undefined behavior as accessing arrays with out-of-bounds indices and accessing out-of-bounds attribute access.

This Pull Request fixes two such cases I found. 

Closes #537 