### PR TITLE
Fix VUID-09548 violations

### DIFF
--- a/external/vulkancts/modules/vulkan/renderpass/vktRenderPassTests.cpp
+++ b/external/vulkancts/modules/vulkan/renderpass/vktRenderPassTests.cpp
@@ -2167,7 +2167,7 @@ void beginCommandBuffer(const DeviceInterface &vk, VkCommandBuffer cmdBuffer, Vk
 
         pInheritanceInfo.pNext = &inheritanceRenderingInfo;
 
-        if (subpassIndex > 0)
+        if (pRenderPassInfo->getSubpasses().size() > 1)
         {
             prepareAttachmentRemapping(subpass, allAttachments, colorAttachmentIndices, colorAttachmentLocations,
                                        colorAttachmentInputIndices, localDepthAttachmentIndex,
@@ -3515,7 +3515,7 @@ void pushDynamicRenderingCommands(const DeviceInterface &vk, VkCommandBuffer com
 
             if (subpassRenderers[subpassNdx]->isSecondary())
             {
-                if (subpassNdx > 0)
+                if (subpassRenderers.size() > 1)
                 {
                     std::vector<uint32_t> colorAttachmentIndices;
                     std::vector<VkFormat> colorAttachmentFormats;


### PR DESCRIPTION
As discussed in https://github.com/KhronosGroup/Vulkan-Docs/issues/2565, we need to set mappings even for the first subpass