### PR TITLE
fix: incorrect uint64_t cast in bitmask limit validation

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
@@ -542,7 +542,7 @@ bool validateFeatureLimits(VkPhysicalDeviceProperties *properties, VkPhysicalDev
                 {
                     log << TestLog::Message << "limit validation failed, " << featureLimitTable[ndx].name
                         << " not valid-limit type bitmask actual is "
-                        << *((uint64_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
+                        << *((uint32_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
                     limitsOk = false;
                 }
             }


### PR DESCRIPTION
Fixes an incorrect cast from `uint32_t` to `uint64_t` when logging bitmask limit validation failures, which causes incorrect values to be displayed in test logs.

### Problem
In the `LIMIT_FORMAT_BITMASK` case of the limit validation code, the actual limit value is checked as a `deUint32`:

```cpp
if ((*((deUint32*)((deUint8*)limits+featureLimitTable[ndx].offset)) & limitToCheck) != limitToCheck)
```
However, when logging the failure, the value is incorrectly cast to deUint64:
```cpp
<< *((deUint64*)((deUint8*)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
```
This mismatch causes the logged value to be incorrect, potentially reading beyond the actual 32-bit field.
Solution
Change the cast in the log output from deUint64* to deUint32* to match the type used in the actual validation check.

### Targeting vulkan-cts-1.3.9
While this bug was originally introduced in commit c82c0fa6ca (April 2016), this PR targets vulkan-cts-1.3.9 because:
Commit 1a09796462 (July 2023, first released in vulkan-cts-1.3.9.0) converted all de* types to standard C++ types (deUint64 to uint64_t)
Earlier branches (1.0.x - 1.3.8) use deUint64 and would require a different patch