### PR TITLE
Adding an option preventing program to return EXIT_FAILURE

### DIFF
--- a/framework/common/tcuCommandLine.cpp
+++ b/framework/common/tcuCommandLine.cpp
@@ -148,6 +148,7 @@ DE_DECLARE_COMMAND_LINE_OPT(ComputeOnly, bool);
 DE_DECLARE_COMMAND_LINE_OPT(VideoLogPrint, bool);
 DE_DECLARE_COMMAND_LINE_OPT(VideoDecodeOutputDump, VideoDecodeOutput);
 DE_DECLARE_COMMAND_LINE_OPT(VideoEncodeOutputDump, VideoEncodeOutput);
+DE_DECLARE_COMMAND_LINE_OPT(NoProgramFail, bool);
 
 static void parseIntList(const char *src, std::vector<int> *dst)
 {
@@ -219,6 +220,7 @@ void registerOptions(de::cmdline::Parser &parser)
         << Option<RunMode>(nullptr, "deqp-runmode",
                            "Execute tests, write list of test cases into a file, or verify amber capability coherency",
                            s_runModes, "execute")
+        << Option<NoProgramFail>(nullptr, "depq-no-program-fail", "Prevents the program to return -1 on test failure", s_enableNames, "disable")
         << Option<ExportFilenamePattern>(nullptr, "deqp-caselist-export-file",
                                          "Set the target file name pattern for caselist export",
                                          "${packageName}-cases.${typeExtension}")
@@ -1186,6 +1188,10 @@ bool CommandLine::parse(const std::string &cmdLine)
 bool CommandLine::quietMode(void) const
 {
     return m_cmdLine.getOption<opt::QuietStdout>();
+}
+bool CommandLine::isNoProgramFailEnabled(void) const
+{
+    return m_cmdLine.getOption<opt::NoProgramFail>();
 }
 const char *CommandLine::getLogFileName(void) const
 {

--- a/framework/common/tcuCommandLine.cpp
+++ b/framework/common/tcuCommandLine.cpp
@@ -220,7 +220,7 @@ void registerOptions(de::cmdline::Parser &parser)
         << Option<RunMode>(nullptr, "deqp-runmode",
                            "Execute tests, write list of test cases into a file, or verify amber capability coherency",
                            s_runModes, "execute")
-        << Option<NoProgramFail>(nullptr, "depq-no-program-fail", "Prevents the program to return -1 on test failure", s_enableNames, "disable")
+        << Option<NoProgramFail>(nullptr, "deqp-no-program-fail", "Prevents the program to return -1 on test failure", s_enableNames, "disable")
         << Option<ExportFilenamePattern>(nullptr, "deqp-caselist-export-file",
                                          "Set the target file name pattern for caselist export",
                                          "${packageName}-cases.${typeExtension}")

--- a/framework/common/tcuCommandLine.hpp
+++ b/framework/common/tcuCommandLine.hpp
@@ -176,6 +176,9 @@ public:
     //! Is quiet mode active?
     bool quietMode(void) const;
 
+    //! Is no program fail mode active?
+    bool isNoProgramFailEnabled(void) const;
+
     //! Get log file name (--deqp-log-filename)
     const char *getLogFileName(void) const;
 

--- a/framework/platform/tcuMain.cpp
+++ b/framework/platform/tcuMain.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
             if (!app->iterate())
             {
                 if (cmdLine.getRunMode() == tcu::RUNMODE_EXECUTE &&
-                    (!app->getResult().isComplete || app->getResult().numFailed))
+                    (!app->getResult().isComplete || app->getResult().numFailed) && !cmdLine.isNoProgramFailEnabled())
                 {
                     exitStatus = EXIT_FAILURE;
                 }


### PR DESCRIPTION
Believe it or not but I have a usecase for this.

This PR adds `--deqp-no-program-fail=[enable|disable]` option that prevents the program to return an exit failure if some tests fail.

I do not believe this will be merged as this is not a very useful option but I'll leave it here just in case.