### PR TITLE
Fixed the error in the return value type of deProcess_create

### DIFF
--- a/framework/delibs/deutil/deProcess.c
+++ b/framework/delibs/deutil/deProcess.c
@@ -138,7 +138,7 @@ deProcess *deProcess_create(void)
 {
     deProcess *process = (deProcess *)deCalloc(sizeof(deProcess));
     if (!process)
-        return false;
+        return NULL;
 
     process->state = PROCESSSTATE_NOT_STARTED;
 


### PR DESCRIPTION
`false` cannot be used with `NULL`.

```bash
VK-GL-CTS/framework/delibs/deutil/deProcess.c: In function 'deProcess_create': VK-GL-CTS/framework/delibs/deutil/deProcess.c:141:16: error: incompatible types when returning type '_Bool' but 'deProcess *' {aka 'struct deProcess_s *'} was expected
  141 |         return false;
      |                ^~~~~
```