### PR TITLE
Fixed a problem of B10G11R11 format

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
@@ -542,7 +542,7 @@ bool validateFeatureLimits(VkPhysicalDeviceProperties *properties, VkPhysicalDev
                 {
                     log << TestLog::Message << "limit validation failed, " << featureLimitTable[ndx].name
                         << " not valid-limit type bitmask actual is "
-                        << *((uint64_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
+                        << *((uint32_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
                     limitsOk = false;
                 }
             }

--- a/framework/common/tcuTexture.cpp
+++ b/framework/common/tcuTexture.cpp
@@ -1719,6 +1719,8 @@ IVec4 ConstPixelBufferAccess::getPixelInt(int x, int y, int z) const
     case TextureFormat::UNSIGNED_INT_1010102_REV:
         return swizzleGe(UVec4(U32(0, 10), U32(10, 10), U32(20, 10), U32(30, 2)), m_format.order, TextureFormat::RGBA)
             .cast<int>();
+    case TextureFormat::UNSIGNED_INT_11F_11F_10F_REV:
+        return swizzleGe(IVec4(U32(0, 11), U32(11, 11), U32(22, 10), 1), m_format.order, TextureFormat::RGB);
     case TextureFormat::SNORM_INT_1010102_REV:   // Fall-through
     case TextureFormat::SSCALED_INT_1010102_REV: // Fall-through
     case TextureFormat::SIGNED_INT_1010102_REV:


### PR DESCRIPTION
In terms of  a DRM format `VK_FORMAT_B10G11R11_UFLOAT_PACK32`.  Once the CTS reads a IVec4 (128 bits) for one pixel, it will go out of boudary for the last pixel, because this format has only 32-bits packed. 

For more, on most OS (e.g. Win, Ubuntu), we can usually get a sort of **clean memory** from kernel. Then this problem would not happened. I tested this occuring in another minor platform (Linux on Arm64) where we are hitting dirty value at the last pixel.   

Hope it will help the graphic software and hardware developers ~