### PR TITLE
deThreadUnix: add __NR_sched_getaffinity macro definition check

### DIFF
--- a/framework/delibs/dethread/unix/deThreadUnix.c
+++ b/framework/delibs/dethread/unix/deThreadUnix.c
@@ -165,7 +165,7 @@ void deYield(void)
 
 uint32_t deGetNumAvailableLogicalCores(void)
 {
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && defined(__NR_sched_getaffinity)
     unsigned long mask          = 0;
     const unsigned int maskSize = sizeof(mask);
     long ret;
@@ -192,7 +192,7 @@ uint32_t deGetNumAvailableLogicalCores(void)
     return 1;
 #endif
 
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && defined(__NR_sched_getaffinity)
     }
 #endif
 }


### PR DESCRIPTION
The [NuttX](https://github.com/apache/nuttx) platform does not support `__NR_sched_getaffinity`; a macro definition has been added to fall back to single-core mode.

```bash
CC:  VK-GL-CTS/framework/delibs/dethread/unix/deThreadUnix.c VK-GL-CTS/framework/delibs/dethread/unix/deThreadUnix.c: In function 'deGetNumAvailableLogicalCores':
VK-GL-CTS/framework/delibs/dethread/unix/deThreadUnix.c:175:11: warning: implicit declaration of function 'syscall'; did you mean 'sys_call0'? [-Wimplicit-function-declaration]
  175 |     ret = syscall(__NR_sched_getaffinity, 0, maskSize, &mask);
      |           ^~~~~~~
      |           sys_call0
VK-GL-CTS/framework/delibs/dethread/unix/deThreadUnix.c:175:19: error: '__NR_sched_getaffinity' undeclared (first use in this function); did you mean 'sched_getaffinity'?
  175 |     ret = syscall(__NR_sched_getaffinity, 0, maskSize, &mask);
      |                   ^~~~~~~~~~~~~~~~~~~~~~
      |                   sched_getaffinity
VK-GL-CTS/framework/delibs/dethread/unix/deThreadUnix.c:175:19: note: each undeclared identifier is reported only once for each function it appears in
```