### PR TITLE
tcuSurfacelessPlatform: add support for custom egl library paths and static linking

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiFeatureInfo.cpp
@@ -542,7 +542,7 @@ bool validateFeatureLimits(VkPhysicalDeviceProperties *properties, VkPhysicalDev
                 {
                     log << TestLog::Message << "limit validation failed, " << featureLimitTable[ndx].name
                         << " not valid-limit type bitmask actual is "
-                        << *((uint64_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
+                        << *((uint32_t *)((uint8_t *)limits + featureLimitTable[ndx].offset)) << TestLog::EndMessage;
                     limitsOk = false;
                 }
             }

--- a/framework/delibs/deutil/deProcess.c
+++ b/framework/delibs/deutil/deProcess.c
@@ -138,7 +138,7 @@ deProcess *deProcess_create(void)
 {
     deProcess *process = (deProcess *)deCalloc(sizeof(deProcess));
     if (!process)
-        return false;
+        return NULL;
 
     process->state = PROCESSSTATE_NOT_STARTED;
 

--- a/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
+++ b/framework/platform/surfaceless/tcuSurfacelessPlatform.cpp
@@ -94,6 +94,14 @@ using std::vector;
 #define DEQP_VULKAN_LIBRARY_PATH DEQP_VULKAN_LIBRARY_BASENAME DEQP_VULKAN_LIBRARY_SUFFIX
 #endif
 
+#if !defined(DEQP_EGL_LIBRARY_PATH)
+#if defined(DEQP_EGL_DIRECT_LINK)
+#define DEQP_EGL_LIBRARY_PATH nullptr // Static linking on embedded - no dynamic library
+#else
+#define DEQP_EGL_LIBRARY_PATH "libEGL.so"
+#endif
+#endif
+
 namespace tcu
 {
 namespace surfaceless
@@ -265,7 +273,7 @@ glu::RenderContext *ContextFactory::createContext(const glu::RenderConfig &confi
 
 EglRenderContext::EglRenderContext(const glu::RenderConfig &config, const tcu::CommandLine &cmdLine,
                                    const glu::RenderContext *sharedContext)
-    : m_egl("libEGL.so")
+    : m_egl(DEQP_EGL_LIBRARY_PATH)
     , m_contextType(config.type)
     , m_eglDisplay(EGL_NO_DISPLAY)
     , m_eglContext(EGL_NO_CONTEXT)


### PR DESCRIPTION
* On some embedded devices, it may be necessary to link a vendor-provided custom EGL library; for example, `brcmEGL.so` is used on Raspberry Pi.

* When `DEQP_EGL_DIRECT_LINK` is enabled, static linking should be used, and the `libEGL.so` file should not be loaded.