### PR TITLE
Fix GLES2 sized depth sampling

### DIFF
--- a/external/openglcts/modules/common/glcInternalformatTests.cpp
+++ b/external/openglcts/modules/common/glcInternalformatTests.cpp
@@ -376,10 +376,10 @@ glu::ProgramSources InternalformatCaseBase::prepareTexturingProgramSources(GLint
              "  gl_FragColor = ${CALCULATE_COLOR};\n"
              "}\n";
 
-        if ((internalFormat == GL_DEPTH_COMPONENT) || (internalFormat == GL_DEPTH_STENCIL))
-            specializationMap["CALCULATE_COLOR"] = "vec4(color.r, 0.0, 0.0, 1.0)";
-        else if (internalFormat == GL_DEPTH_COMPONENT32F)
+        if (internalFormat == GL_DEPTH_COMPONENT32F)
             specializationMap["CALCULATE_COLOR"] = "vec4(color.r, color.r, color.r, 1.0)";
+        else if ((format == GL_DEPTH_COMPONENT) || (format == GL_DEPTH_STENCIL))
+            specializationMap["CALCULATE_COLOR"] = "vec4(color.r, 0.0, 0.0, 1.0)";
         else
             specializationMap["CALCULATE_COLOR"] = "color";
     }


### PR DESCRIPTION
The GLES2 shader path only zeroed G/B when internalFormat was the unsized GL_DEPTH_COMPONENT/GL_DEPTH_STENCIL, so sized depth formats exposed by OES_required_internalformat (e.g. GL_DEPTH_COMPONENT16/24) were treated as color. Just check the unsized format for the depth/stencil.

Components: OpenGL

Affected tests:
KHR-GLES2.core.internalformat.texture2d.depth_component_unsigned_int_depth_component16
KHR-GLES2.core.internalformat.texture2d.depth_component_unsigned_short_depth_component16
KHR-GLES2.core.internalformat.texture2d.depth_component_unsigned_int_depth_component24
KHR-GLES2.core.internalformat.texture2d.depth_component_unsigned_int_depth_component32