### PR TITLE
Fix EGL render tests for rgba16 and rgb16 unorm fixed point surfaces.

### DIFF
--- a/modules/egl/teglRenderTests.cpp
+++ b/modules/egl/teglRenderTests.cpp
@@ -365,6 +365,10 @@ tcu::TextureFormat getColorFormat(const tcu::PixelFormat &colorBits)
         return TextureFormat(TextureFormat::RGBA, TextureFormat::UNORM_INT_1010102_REV);
     case PACK_FMT(10, 10, 10, 0):
         return TextureFormat(TextureFormat::RGB, TextureFormat::UNORM_INT_101010);
+    case PACK_FMT(16, 16, 16, 16):
+        return TextureFormat(TextureFormat::RGBA, TextureFormat::UNORM_INT16);
+    case PACK_FMT(16, 16, 16, 0):
+        return TextureFormat(TextureFormat::RGB, TextureFormat::UNORM_INT16);
     // \note Defaults to RGBA8
     default:
         return TextureFormat(TextureFormat::RGBA, TextureFormat::UNORM_INT8);


### PR DESCRIPTION
This commit makes EGL render tests work for 16 bpc RGB16 UNORM and RGBA16 UNORM formats, by adding suitable new formats to getColorFormat.

The Mesa open-source graphics library wants to add support to its EGL backend for 16 bpc RGB16 and RGBA16 displayable surfaces and pbuffers to allow rendering and displaying > 10 bpc color precision content on suitable display hardware. As VK-GL-CTS is used as part of Mesa's CI pipeline, this causes test failures due to mismatch between hardware rendered test images and the reference images rendered by the software rasterizer. This is because there isn't a case in getColorFormat to map PACK_FMT's with 16 bpc to a suitable TextureFormat.

Adding the needed case handling to getColorFormat does fix this EGL render test failure.

Affects:
dEQP-EGL.functional.render.*