### PR TITLE
vktWsiPresentTimingTests.cpp: Fix disallowed partial past timing result check

### DIFF
--- a/external/vulkancts/modules/vulkan/wsi/vktWsiPresentTimingTests.cpp
+++ b/external/vulkancts/modules/vulkan/wsi/vktWsiPresentTimingTests.cpp
@@ -970,12 +970,12 @@ uint32_t getPastPresentationTiming(const DeviceInterface &vkd, vk::VkDevice devi
         if (pth.timings[i].presentStageCount < 1)
             TCU_FAIL("Unexpected present stage count");
 
+        if (!(pth.pastPresentationTimingFlags & VK_PAST_PRESENTATION_TIMING_ALLOW_PARTIAL_RESULTS_BIT_EXT) &&
+            !pth.timings[i].reportComplete)
+            TCU_FAIL("Received partial result when disallowed");
+
         if (pth.timings[i].reportComplete)
         {
-            if (!(pth.pastPresentationTimingFlags & VK_PAST_PRESENTATION_TIMING_ALLOW_PARTIAL_RESULTS_BIT_EXT) &&
-                !pth.timings[i].reportComplete)
-                TCU_FAIL("Received partial result when disallowed");
-
             PresentResult result;
 
             if (pth.timings[i].presentStageCount != pth.stageCount)


### PR DESCRIPTION
The condition: 
```
!(pth.pastPresentationTimingFlags & VK_PAST_PRESENTATION_TIMING_ALLOW_PARTIAL_RESULTS_BIT_EXT) &&
            !pth.timings[i].reportComplete
```
will always evaluated to false within the if statement
```
if (pth.timings[i].reportComplete) {
```

I came across this while reading the CTS to learn how to use `VK_EXT_present_timing` in my vulkan application.