### PR TITLE
Implement setVisible for VulkanWindowHeadless

### DIFF
--- a/framework/platform/lnx/tcuLnxVulkanPlatform.cpp
+++ b/framework/platform/lnx/tcuLnxVulkanPlatform.cpp
@@ -234,6 +234,10 @@ private:
 struct VulkanWindowHeadless : public vk::wsi::Window
 {
 public:
+    void setVisible(bool visible) override
+    {
+        DE_UNREF(visible);
+    }
     void resize(const UVec2 &)
     {
     }


### PR DESCRIPTION
The VulkanWindowHeadless class currently has setVisible() function missing, which prevents swapchain_maintence1 tests from properly running.

As the "window" of Headless WSI is never seen externally, this function should be trivial (doing nothing) on the Headless WSI.

Add such a trivial implementation of setVisible() to VulkanWindowHeadless class.

Fixes #586 .