### PR TITLE
robustness: allow nullDescriptor without buffer/image robustness2

### DIFF
--- a/external/vulkancts/modules/vulkan/robustness/vktRobustnessExtsTests.cpp
+++ b/external/vulkancts/modules/vulkan/robustness/vktRobustnessExtsTests.cpp
@@ -635,12 +635,12 @@ void RobustnessExtsTestCase::checkSupport(Context &context) const
     case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
     case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
     case VERTEX_ATTRIBUTE_FETCH:
-        if (m_data.testRobustness2)
+        if (m_data.testRobustness2 && !m_data.nullDescriptor)
         {
             if (!robustness2Features.robustBufferAccess2)
                 TCU_THROW(NotSupportedError, "robustBufferAccess2 not supported");
         }
-        else
+        else if (!m_data.nullDescriptor)
         {
             // This case is not tested here.
             DE_ASSERT(false);
@@ -648,12 +648,12 @@ void RobustnessExtsTestCase::checkSupport(Context &context) const
         break;
     case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
     case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-        if (m_data.testRobustness2)
+        if (m_data.testRobustness2 && !m_data.nullDescriptor)
         {
             if (!robustness2Features.robustImageAccess2)
                 TCU_THROW(NotSupportedError, "robustImageAccess2 not supported");
         }
-        else
+        else if (!m_data.nullDescriptor)
         {
             if (!imageRobustnessFeatures.robustImageAccess)
                 TCU_THROW(NotSupportedError, "robustImageAccess not supported");


### PR DESCRIPTION
**Note**: I am targeting `main` because I am unsure of the earliest release branch this bug applies to. Please let me know if I should retarget this to a specific branch.

**Description**

`nullDescriptor` is an independent bit in `VkPhysicalDeviceRobustness2FeaturesEXT`.
The Vulkan spec does not require `robustBufferAccess2` or `robustImageAccess2` to be
supported in order to use `nullDescriptor`. However, `checkSupport()` was gating all
buffer-type and image-type null descriptor tests behind those features, causing
them to be skipped on any device where `robustBufferAccess2` or `robustImageAccess2`
is not available.