### PR TITLE
Add Rayquery amber test

### DIFF
--- a/external/vulkancts/data/vulkan/amber/ray_query/ray_query_workgroup_barrier.amber
+++ b/external/vulkancts/data/vulkan/amber/ray_query/ray_query_workgroup_barrier.amber
@@ -1,0 +1,115 @@
+#!amber
+
+# Ray query stress test with workgroup barrier and serialized Proceed() per subgroup lane.
+# Uses compute shader with WG size 1024. Each invocation initializes a ray query against
+# a non-opaque triangle, synchronizes via barrier(), then serializes Proceed() across
+
+DEVICE_EXTENSION VK_KHR_acceleration_structure
+DEVICE_EXTENSION VK_KHR_ray_query
+DEVICE_EXTENSION VK_KHR_buffer_device_address
+DEVICE_EXTENSION VK_KHR_spirv_1_4
+DEVICE_FEATURE   AccelerationStructureFeaturesKHR.accelerationStructure
+DEVICE_FEATURE   RayQueryFeaturesKHR.rayQuery
+DEVICE_FEATURE   BufferDeviceAddressFeatures.bufferDeviceAddress
+
+SHADER compute ray_query_shader GLSL TARGET_ENV spv1.4
+#version 460 core
+#extension GL_EXT_ray_query : require
+#extension GL_KHR_shader_subgroup_basic : require
+
+layout(local_size_x = 1024) in;
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT topLevelAS;
+layout(set = 0, binding = 1) buffer OutputBuffer {
+    uint results[];
+};
+layout(set = 0, binding = 2) buffer DelayBuffer {
+    uint delayData[];
+};
+
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+
+    // Set up ray that is guaranteed to hit exactly one non-opaque triangle.
+    vec3 origin = vec3(0.0, 0.0, -2.0);
+    vec3 direction = vec3(0.0, 0.0, 1.0);
+    float tMin = 0.001;
+    float tMax = 100.0;
+
+    rayQueryEXT rq;
+    rayQueryInitializeEXT(rq, topLevelAS, gl_RayFlagsNoneEXT, 0xFF,
+                          origin, tMin, direction, tMax);
+
+    // Workgroup barrier - all invocations have initialized their ray query.
+    barrier();
+
+    // Serialize Proceed() across subgroup lanes.
+    for (uint curLane = 0; curLane < 32; ++curLane) {
+        if (gl_SubgroupInvocationID == curLane) {
+            rayQueryProceedEXT(rq);
+        }
+        if (curLane == 0) {
+            // Delay to allow other waves of the WG to issue the first Proceed() call.
+            // Uses buffer accesses in a loop to prevent compiler optimization.
+            uint dummy = 0;
+            for (uint i = 0; i < 256; i++) {
+                dummy += delayData[i % 64];
+            }
+            // Prevent the loop from being optimized away.
+            if (dummy == 0xDEADBEEF) {
+                results[gid] = dummy;
+            }
+        }
+    }
+
+    // Accept the candidate hit (non-opaque triangle requires explicit confirmation).
+    rayQueryConfirmIntersectionEXT(rq);
+
+    // Store result depending on the committed hit.
+    if (rayQueryGetIntersectionTypeEXT(rq, true) ==
+        gl_RayQueryCommittedIntersectionTriangleEXT) {
+        results[gid] = 1;
+    } else {
+        results[gid] = 0;
+    }
+}
+END
+
+# Triangle geometry - single non-opaque triangle centered at origin, facing -Z.
+ACCELERATION_STRUCTURE BOTTOM_LEVEL triangle_blas
+  GEOMETRY TRIANGLES
+    0.0 -1.0 0.0
+    -1.0 1.0 0.0
+    1.0 1.0 0.0
+  END
+END
+
+# Top level AS with FORCE_NO_OPAQUE to ensure the triangle is non-opaque,
+# requiring explicit AcceptHit (confirmIntersection) in the ray query.
+ACCELERATION_STRUCTURE TOP_LEVEL triangle_tlas
+  BOTTOM_LEVEL_INSTANCE triangle_blas
+    FLAGS FORCE_NO_OPAQUE
+  END
+END
+
+# Output buffer: 1024 uints, one per invocation.
+BUFFER out_buf DATA_TYPE uint32 SIZE 1024 FILL 0
+
+# Delay buffer: 64 uints with arbitrary data for delay loop reads.
+BUFFER delay_buf DATA_TYPE uint32 SIZE 64 FILL 7
+
+PIPELINE compute ray_query_pipeline
+  ATTACH ray_query_shader
+  BIND ACCELERATION_STRUCTURE triangle_tlas DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER out_buf AS storage DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER delay_buf AS storage DESCRIPTOR_SET 0 BINDING 2
+END
+
+# Dispatch 1 workgroup of 1024 invocations.
+RUN ray_query_pipeline 1 1 1
+
+# Every invocation should have hit the triangle and written 1.
+EXPECT out_buf IDX 0 EQ 1
+EXPECT out_buf IDX 4 EQ 1
+EXPECT out_buf IDX 2044 EQ 1
+EXPECT out_buf IDX 4092 EQ 1

--- a/external/vulkancts/data/vulkan/amber/ray_query/ray_query_workgroup_barrier.amber
+++ b/external/vulkancts/data/vulkan/amber/ray_query/ray_query_workgroup_barrier.amber
@@ -42,13 +42,13 @@ void main() {
 
     // Workgroup barrier - all invocations have initialized their ray query.
     barrier();
-
+    bool proceed = false;
     // Serialize Proceed() across subgroup lanes.
-    for (uint curLane = 0; curLane < 32; ++curLane) {
+    for (uint curLane = 0; curLane < gl_SubgroupSize; ++curLane) {
         if (gl_SubgroupInvocationID == curLane) {
-            rayQueryProceedEXT(rq);
+            proceed = rayQueryProceedEXT(rq);
         }
-        if (curLane == 0) {
+        if (curLane == 0 && proceed) {
             // Delay to allow other waves of the WG to issue the first Proceed() call.
             // Uses buffer accesses in a loop to prevent compiler optimization.
             uint dummy = 0;
@@ -63,14 +63,16 @@ void main() {
     }
 
     // Accept the candidate hit (non-opaque triangle requires explicit confirmation).
-    rayQueryConfirmIntersectionEXT(rq);
+    if (proceed) {
+        rayQueryConfirmIntersectionEXT(rq);
 
-    // Store result depending on the committed hit.
-    if (rayQueryGetIntersectionTypeEXT(rq, true) ==
-        gl_RayQueryCommittedIntersectionTriangleEXT) {
-        results[gid] = 1;
-    } else {
-        results[gid] = 0;
+        // Store result depending on the committed hit.
+        if (rayQueryGetIntersectionTypeEXT(rq, true) ==
+            gl_RayQueryCommittedIntersectionTriangleEXT) {
+            results[gid] = 1;
+        } else {
+            results[gid] = 0;
+        }
     }
 }
 END

--- a/external/vulkancts/modules/vulkan/amber/vktAmberTestCase.cpp
+++ b/external/vulkancts/modules/vulkan/amber/vktAmberTestCase.cpp
@@ -138,6 +138,8 @@ static bool isFeatureSupported(const vkt::Context &ctx, const std::string &featu
         return ctx.getIndexTypeUint8Features().indexTypeUint8;
     if (feature == "RayTracingPipelineFeaturesKHR.rayTracingPipeline")
         return ctx.getRayTracingPipelineFeatures().rayTracingPipeline;
+    if (feature == "RayQueryFeaturesKHR.rayQuery")
+        return ctx.getRayQueryFeatures().rayQuery;
     if (feature == "AccelerationStructureFeaturesKHR.accelerationStructure")
         return ctx.getAccelerationStructureFeatures().accelerationStructure;
     if (feature == "BufferDeviceAddressFeatures.bufferDeviceAddress")

--- a/external/vulkancts/modules/vulkan/ray_query/CMakeLists.txt
+++ b/external/vulkancts/modules/vulkan/ray_query/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(
 )
 
 set(DEQP_VK_RAY_QUERY_SRCS
+	vktRayQueryAmberTests.cpp
+	vktRayQueryAmberTests.hpp
 	vktRayQueryTests.cpp
 	vktRayQueryTests.hpp
 	vktRayQueryBuiltinTests.cpp

--- a/external/vulkancts/modules/vulkan/ray_query/vktRayQueryAmberTests.cpp
+++ b/external/vulkancts/modules/vulkan/ray_query/vktRayQueryAmberTests.cpp
@@ -1,0 +1,76 @@
+/*-------------------------------------------------------------------------
+ * Vulkan Conformance Tests
+ * ------------------------
+ *
+ * Copyright (c) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *//*!
+ * \file
+ * \brief Ray Query Amber Tests
+ *//*--------------------------------------------------------------------*/
+
+#include "vktRayQueryAmberTests.hpp"
+#include "vktTestCase.hpp"
+#include "amber/vktAmberTestCase.hpp"
+
+namespace vkt
+{
+namespace RayQuery
+{
+
+tcu::TestCaseGroup *createAmberTests(tcu::TestContext &testCtx)
+{
+    de::MovePtr<tcu::TestCaseGroup> group(new tcu::TestCaseGroup(testCtx, "amber", "Amber ray query test cases"));
+
+#ifndef CTS_USES_VULKANSC
+    const char *rayQueryList[] = {"AccelerationStructureFeaturesKHR.accelerationStructure",
+                                  "RayQueryFeaturesKHR.rayQuery",
+                                  "BufferDeviceAddressFeatures.bufferDeviceAddress",
+                                  "VK_KHR_acceleration_structure",
+                                  "VK_KHR_ray_query",
+                                  "VK_KHR_buffer_device_address",
+                                  "VK_KHR_spirv_1_4",
+                                  ""};
+    const struct
+    {
+        const char *name;
+        const char *fileName;
+        const char *const *requirements;
+    } amberTests[] = {
+        {"workgroup_barrier", "ray_query_workgroup_barrier.amber", rayQueryList},
+    };
+
+    const char *dataDir = "ray_query";
+    for (auto test : amberTests)
+    {
+        cts_amber::AmberTestCase *testCase = cts_amber::createAmberTestCase(testCtx, test.name, "", dataDir, test.fileName);
+
+        for (size_t i = 0;; i++)
+        {
+            const char *requirement = test.requirements[i];
+            if (requirement[0] == 0)
+                break;
+            testCase->addRequirement(requirement);
+        }
+
+        group->addChild(testCase);
+    }
+#endif
+
+    return group.release();
+}
+
+} // namespace RayQuery
+} // namespace vkt

--- a/external/vulkancts/modules/vulkan/ray_query/vktRayQueryAmberTests.hpp
+++ b/external/vulkancts/modules/vulkan/ray_query/vktRayQueryAmberTests.hpp
@@ -1,0 +1,39 @@
+#ifndef _VKTRAYQUERYAMBERTESTS_HPP
+#define _VKTRAYQUERYAMBERTESTS_HPP
+/*-------------------------------------------------------------------------
+ * Vulkan Conformance Tests
+ * ------------------------
+ *
+ * Copyright (c) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *//*!
+ * \file
+ * \brief Ray Query Amber Tests
+ *//*--------------------------------------------------------------------*/
+
+#include "tcuDefs.hpp"
+#include "tcuTestCase.hpp"
+
+namespace vkt
+{
+namespace RayQuery
+{
+
+tcu::TestCaseGroup *createAmberTests(tcu::TestContext &testCtx);
+
+} // namespace RayQuery
+} // namespace vkt
+
+#endif // _VKTRAYQUERYAMBERTESTS_HPP

--- a/external/vulkancts/modules/vulkan/ray_query/vktRayQueryTests.cpp
+++ b/external/vulkancts/modules/vulkan/ray_query/vktRayQueryTests.cpp
@@ -22,6 +22,7 @@
  *//*--------------------------------------------------------------------*/
 
 #include "vktRayQueryTests.hpp"
+#include "vktRayQueryAmberTests.hpp"
 #include "vktRayQueryBuiltinTests.hpp"
 #include "vktRayQueryTraversalControlTests.hpp"
 #include "vktRayQueryAccelerationStructuresTests.hpp"
@@ -50,6 +51,7 @@ tcu::TestCaseGroup *createTests(tcu::TestContext &testCtx, const std::string &na
 {
     de::MovePtr<tcu::TestCaseGroup> group(new tcu::TestCaseGroup(testCtx, name.c_str()));
 
+    group->addChild(createAmberTests(testCtx));
     group->addChild(createBuiltinTests(testCtx));
     group->addChild(createTraversalControlTests(testCtx));
     group->addChild(createAccelerationStructuresTests(testCtx));


### PR DESCRIPTION
It introduces dEQP-VK.ray_query.amber.workgroup_barrier, backed by: ray_query_workgroup_barrier.amber

The Amber script creates a compute shader using GL_EXT_ray_query, inds a TLAS, output buffer, and delay buffer, then dispatches one 1024-invocation workgroup.

Important caveat: this commit only adds the CTS-side ray query Amber test and feature check. It currently is dependent on the PR https://github.com/google/amber/pull/1118