### PR TITLE
Require VK_NV_cooperative_matrix2 for coopmat_64b_tensorlayout

### DIFF
--- a/external/vulkancts/modules/vulkan/compute/vktComputeCooperativeMatrixTests.cpp
+++ b/external/vulkancts/modules/vulkan/compute/vktComputeCooperativeMatrixTests.cpp
@@ -6400,6 +6400,16 @@ void CoopMat64bTest::checkSupport(Context &context) const
                                   m_computePipelineConstructionType);
     if (!context.getShader64BitIndexingFeaturesEXT().shader64BitIndexing)
         TCU_THROW(NotSupportedError, "shader64BitIndexing not supported by this implementation");
+
+    // The tensor-layout variant emits coopMatLoadTensorNV/coopMatStoreTensorNV (tensor
+    // addressing), so it additionally requires VK_NV_cooperative_matrix2; mirror the gate
+    // in CooperativeMatrixTestCase::checkSupport rather than assuming it from 64-bit indexing.
+    if (m_tensorLayout)
+    {
+        context.requireDeviceFunctionality("VK_NV_cooperative_matrix2");
+        if (!context.getCooperativeMatrix2FeaturesNV().cooperativeMatrixTensorAddressing)
+            TCU_THROW(NotSupportedError, "cooperativeMatrixTensorAddressing not supported");
+    }
 }
 
 void CoopMat64bTest::initPrograms(SourceCollections &sourceCollections) const


### PR DESCRIPTION
## Problem

The tensor-layout variants
`dEQP-VK.compute.*.cooperative_matrix.64b_indexing.coopmat_64b_tensorlayout*`
(across the `pipeline`, `shader_object_binary` and `shader_object_spirv` groups)
generate GLSL using `coopMatLoadTensorNV` / `coopMatStoreTensorNV` /
`tensorLayoutNV` — i.e. SPV_NV_cooperative_matrix2 tensor addressing
(`SpvCapabilityCooperativeMatrixTensorAddressingNV`).

But `CoopMat64bTest::checkSupport` only requires shader-object support and
`VkPhysicalDeviceShader64BitIndexingFeaturesEXT::shader64BitIndexing`. There is
no check for `VK_NV_cooperative_matrix2` / `cooperativeMatrixTensorAddressing`.

On an implementation that exposes `VK_EXT_shader_64bit_indexing` and
`VK_KHR_cooperative_matrix` but **not** `VK_NV_cooperative_matrix2`, the test
emits SPIR-V using a capability the driver never advertised. Instead of reporting
`NotSupported` it fails SPIR-V parsing and aborts the run. The sibling
`coopmat_64b_rowmajor*` cases, which use only KHR cooperative matrix features,
run correctly.

## Fix

Gate the tensor-layout path on `VK_NV_cooperative_matrix2` +
`VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixTensorAddressing`,
mirroring the existing `TT_TENSORLAYOUT_*` handling in
`CooperativeMatrixTestCase::checkSupport`. The `rowmajor` variants are unaffected.

## Testing

Mesa RADV (gfx1151), which exposes `VK_EXT_shader_64bit_indexing` but not
`VK_NV_cooperative_matrix2`:

| Case | Before | After |
|------|--------|-------|
| `coopmat_64b_tensorlayout` (×9: pipeline / shader_object_binary / shader_object_spirv × base/medium/large offset) | SPIR-V parse failure, run aborts | **NotSupported** |
| `coopmat_64b_rowmajor` (×2) | Pass | Pass |

After the fix the group completes cleanly: 2 Pass, 0 Fail, 9 NotSupported.

## Affected tests

`dEQP-VK.compute.*.cooperative_matrix.64b_indexing.coopmat_64b_tensorlayout*`
