### PR TITLE
Fix VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-04735 in closest-hit ray query test

### DIFF
--- a/external/vulkancts/framework/vulkan/vkRayTracingUtil.hpp
+++ b/external/vulkancts/framework/vulkan/vkRayTracingUtil.hpp
@@ -1877,7 +1877,6 @@ std::vector<T> rayQueryRayTracingTestSetup(const vk::DeviceInterface &vkd, const
     {
         hitGroup  = 1;
         missGroup = 2;
-        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
         rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
         rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
     }
@@ -1885,7 +1884,6 @@ std::vector<T> rayQueryRayTracingTestSetup(const vk::DeviceInterface &vkd, const
     {
         hitGroup  = 1;
         missGroup = 2;
-        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
         rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
         rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
     }


### PR DESCRIPTION
`rayQueryRayTracingTestSetup` in `vkRayTracingUtil.hpp` has the following code:

```c++
    if (rgenRTTest)
    {
        hitGroup  = 1;
        missGroup = 2;
        if (params.triangles == false)
        {
            rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        }
        rt_pipeline->addShader(VK_SHADER_STAGE_ANY_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[3].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[4].get()->get(), missGroup);
    }
    else if (ahitTest)
    {
        hitGroup  = 1;
        missGroup = 2;
        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_ANY_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
    }
    else if (missTest)
    {
        hitGroup  = 1;
        missGroup = 2;
        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
    }
    else if (chitTest)
    {
        hitGroup  = 1;
        missGroup = 2;
        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
    }
    else if (isectTest)
    {
        hitGroup  = 1;
        missGroup = 2;
        rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[2].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[3].get()->get(), missGroup);
    }
    else if (callTest)
    {
        hitGroup      = 1;
        missGroup     = 2;
        callableGroup = 3;
        rt_pipeline->addShader(VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, shaderModules[1].get()->get(), hitGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_MISS_BIT_KHR, shaderModules[2].get()->get(), missGroup);
        rt_pipeline->addShader(VK_SHADER_STAGE_CALLABLE_BIT_KHR, shaderModules[3].get()->get(), callableGroup);
    }
 ```
 
 When `rt_pipeline->addShader(VK_SHADER_STAGE_INTERSECTION_BIT_KHR, ...` was called, it implies that the test variant will be using a procedural hit group. In Vulkan, procedural hitgroups must have intersection shader [VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03476](https://vkdoc.net/man/VkRayTracingShaderGroupCreateInfoKHR#VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03476); triangle hitgroups must not have intersection shaders [VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03477](https://vkdoc.net/man/VkRayTracingShaderGroupCreateInfoKHR#VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03477)
 
However, later in that same function, we have
```c++
    switch (params.shaderSourceType)
    {
    case RayQueryShaderSourceType::MISS:
        geomData.push_back(tcu::Vec3(0, 0, -1));
        geomData.push_back(tcu::Vec3(1, 0, -1));
        geomData.push_back(tcu::Vec3(0, 1, -1));
        break;
    case RayQueryShaderSourceType::CLOSEST_HIT:
    case RayQueryShaderSourceType::CALLABLE:
        geomData.push_back(tcu::Vec3(0, 0, 1));
        geomData.push_back(tcu::Vec3(1, 0, 1));
        geomData.push_back(tcu::Vec3(0, 1, 1));
        break;
    case RayQueryShaderSourceType::ANY_HIT:
    case RayQueryShaderSourceType::INTERSECTION:
        geomData.push_back(tcu::Vec3(0, 0, 1));
        geomData.push_back(tcu::Vec3(0.5, 0.5, 1));
        break;
    default:
        break;
    }
```
which implies that the closest hit test will be using a triangle geometry. (We decide whether to use a triangle or AABB geometry later on this line: `traceBottomLevelAccelerationStructure->addGeometry(geomData, ((geomData.size() % 3) == 0), 0);` by checking whether `(geomData.size() % 3) == 0`.

This violates  [VUID-VkTraceRaysIndirectCommand2KHR-pHitShaderBindingTable-04735](https://vkdoc.net/man/VkTraceRaysIndirectCommand2KHR#VUID-VkTraceRaysIndirectCommand2KHR-pHitShaderBindingTable-04735)

> Any non-zero hit shader group entries in the table identified by hitShaderBindingTableAddress accessed by this call from a geometry with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR must have been created with VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR

 
 Affected tests:
* `dEQP-VK.ray_query.multiple_ray_queries.chit_shader`
* `dEQP-VK.ray_query.stress.chit_shader.*`