### PR TITLE
Fix build for LLVM's remove transitive includes

### DIFF
--- a/external/vulkancts/modules/vulkan/sparse_resources/vktSparseResourcesTestsUtil.cpp
+++ b/external/vulkancts/modules/vulkan/sparse_resources/vktSparseResourcesTestsUtil.cpp
@@ -30,6 +30,8 @@
 
 #include <deMath.h>
 
+#include <iterator>
+
 using namespace vk;
 
 namespace vkt


### PR DESCRIPTION
In the latest LLVM roll this file requires the iterator header for std::back_inserter

I believe LLVM has recently removed transitive includes by default, see:

https://github.com/llvm/llvm-project/commit/ce5b2e876494cb95f02d9f915081e2b8781e74d1