### PR TITLE
Fix Windows/ARM64 GL typedefs

### DIFF
--- a/framework/opengl/wrapper/glwTypes.inl
+++ b/framework/opengl/wrapper/glwTypes.inl
@@ -70,7 +70,7 @@ typedef int32_t				GLsizei;
 typedef int32_t				GLfixed;
 typedef void				GLvoid;
 
-#if (DE_OS == DE_OS_WIN32 && DE_CPU == DE_CPU_X86_64)
+#if (DE_OS == DE_OS_WIN32 && (DE_CPU == DE_CPU_X86_64 || DE_CPU == DE_CPU_ARM_64))
 	typedef signed long long int	GLintptr;
 	typedef signed long long int	GLsizeiptr;
 #else


### PR DESCRIPTION
Fixes the OpenGL wrapper using 32-bit integers for GL pointers when compiling for Windows/ARM64. This was already worked around for x64, but the same workaround never got applied to ARM64.

This fixes a compile error in ANGLE caused by a combination of several casts in glcCullDistance.cpp, -Wint-to-void-pointer-cast, and treating warnings as errors.