### PR TITLE
relax ownership validation for pipeline allocs in device memory reports

### DIFF
--- a/external/vulkancts/modules/vulkan/memory/vktMemoryDeviceMemoryReportTests.cpp
+++ b/external/vulkancts/modules/vulkan/memory/vktMemoryDeviceMemoryReportTests.cpp
@@ -1658,6 +1658,11 @@ tcu::TestCaseGroup *createObjectTestsGroup(tcu::TestContext &testCtx, const char
     return group.release();
 }
 
+static bool isPipelineRelatedObjectType(VkObjectType objectType)
+{
+    return objectType == VK_OBJECT_TYPE_PIPELINE || objectType == VK_OBJECT_TYPE_PIPELINE_CACHE;
+}
+
 static bool validateCallbackRecords(Context &context, const InstanceWrapper &instance, const CallbackRecorder &recorder)
 {
     tcu::TestLog &log                                       = context.getTestContext().getLog();
@@ -1665,6 +1670,7 @@ static bool validateCallbackRecords(Context &context, const InstanceWrapper &ins
     const InstanceInterface &vki                            = instance.getDriver();
     const VkPhysicalDeviceMemoryProperties memoryProperties = getPhysicalDeviceMemoryProperties(vki, physicalDevice);
     std::set<std::pair<uint64_t, uint64_t>> memoryObjectSet;
+    std::set<uint64_t> pipelineRelatedMemoryObjectIds;
 
     for (auto iter = recorder.getRecordsBegin(); iter != recorder.getRecordsEnd(); iter++)
     {
@@ -1690,6 +1696,9 @@ static bool validateCallbackRecords(Context &context, const InstanceWrapper &ins
         if (record.type == VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_ALLOCATE_EXT ||
             record.type == VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_IMPORT_EXT)
         {
+            if (isPipelineRelatedObjectType(record.objectType))
+                pipelineRelatedMemoryObjectIds.insert(record.memoryObjectId);
+
             memoryObjectSet.insert(std::make_pair(record.memoryObjectId, record.objectHandle));
             continue;
         }
@@ -1697,6 +1706,30 @@ static bool validateCallbackRecords(Context &context, const InstanceWrapper &ins
         if (record.type == VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_FREE_EXT ||
             record.type == VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_UNIMPORT_EXT)
         {
+            if (pipelineRelatedMemoryObjectIds.count(record.memoryObjectId))
+            {
+                bool found = false;
+                for (const auto &pair : memoryObjectSet)
+                {
+                    if (pair.first == record.memoryObjectId)
+                    {
+                        memoryObjectSet.erase(pair);
+                        pipelineRelatedMemoryObjectIds.erase(record.memoryObjectId);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    log << tcu::TestLog::Message << "Unpaired or out-of-order free/unimport event"
+                        << tcu::TestLog::EndMessage;
+                    log << tcu::TestLog::Message << record << tcu::TestLog::EndMessage;
+                    return false;
+                }
+
+                continue;
+            }
             const auto objectPair = std::make_pair(record.memoryObjectId, record.objectHandle);
             if (!memoryObjectSet.count(objectPair))
             {


### PR DESCRIPTION
We ran into this while implementing VK_EXT_device_memory_report in v3dv. The relevant CTS tests validate that `objectHandle` in a `FREE_EXT`/`UNIMPORT_EXT` event matches a specific object and that the objectHandle is the same as the corresponding `ALLOC_EXT`/`IMPORT_EXT`. This breaks down when the underlying allocation is refcounted and shared across objects with independent lifetimes.

For example, pipeline shader binary storage may be shared between a `VkPipeline` and a `VkPipelineCache` that both hold a reference to it.
1. Create pipeline P with cache C. Both hold a reference.
2. Destroy C. Allocation stays alive via P. C is no longer valid.
3. Destroy P. This drops the last reference and frees the allocation.

At step 1, the driver needs to report an `ALLOC_EXT`/`IMPORT_EXT` with a vulkan handle, which could be that of the pipeline cache or the pipeline itself. Additionally, at step 3, no single fixed "owner" handle is guaranteed valid, whichever object we pick to attribute at allocation time or at each ownership transfer may later be destroyed while the memory is still alive through someone else. A similar issue also applies to `vkMergePipelineCaches`.

Since the spec doesn't seem to include the requirement that vulkan handles for ALLOC/FREE must match, this change relaxes this requirement, at least for the cases of pipeline allocations, allowing FREEs to be reported from pipeline cache objects (including pipeline caches created internally by the driver).

Affects: dEQP-VK.memory.device_memory_report*

Components: Vulkan