### PR TITLE
Refactor aspect determination for input attachments

### DIFF
--- a/external/vulkancts/modules/vulkan/renderpass/vktRenderPassTests.cpp
+++ b/external/vulkancts/modules/vulkan/renderpass/vktRenderPassTests.cpp
@@ -7001,8 +7001,8 @@ void addAttachmentAllocationTests(tcu::TestCaseGroup *group, const TestConfigExt
                                 VkImageAspectFlags aspect = 0u;
                                 if (testConfigExternal.groupParams->renderingType == RENDERING_TYPE_RENDERPASS2)
                                 {
-                                    bool col = colorAttachments.find(inputAttachmentIndex) != colorAttachments.end();
-                                    aspect   = col ? VK_IMAGE_ASPECT_COLOR_BIT : VK_IMAGE_ASPECT_DEPTH_BIT;
+                                    const VkFormat format = attachments[inputAttachmentIndex].getFormat();
+                                    aspect                = getImageAspectFlags(format);
                                 }
                                 inputAttachmentReferences.push_back(
                                     AttachmentReference((uint32_t)subpassInputAttachments[inputAttachmentNdx],


### PR DESCRIPTION
Fix the input attachment aspect mask generated by the render pass attachment allocation tests.
Previously, all non-color input attachments were assigned only VK_IMAGE_ASPECT_DEPTH_BIT. This is incorrect for combined depth/stencil formats because the generated fragment shader creates separate depth and stencil input attachment views and reads both aspects using subpassLoad().